### PR TITLE
docker: pin rabbitmq to version 3

### DIFF
--- a/integration_tests/assets/docker-compose.all_routes.override.yml
+++ b/integration_tests/assets/docker-compose.all_routes.override.yml
@@ -15,6 +15,6 @@ services:
       - "./tmp/data/asset.all_routes.test.csv:/tmp/data/test.csv"
       - "./tmp/data/asset.all_routes.test_no_email.csv:/tmp/data/test_no_email.csv"
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3
     ports:
       - "5672"

--- a/integration_tests/assets/docker-compose.personal_only.override.yml
+++ b/integration_tests/assets/docker-compose.personal_only.override.yml
@@ -9,6 +9,6 @@ services:
       TARGETS: "dird:9489 auth:9497 db:5432 rabbitmq:5672"
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3
     ports:
       - "5672"

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - "5432"
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3
     ports:
       - "5672"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only pins the RabbitMQ Docker image tag used by integration-test `docker-compose` configs, with no application code changes.
> 
> **Overview**
> Pins the RabbitMQ container used by integration tests from the floating `rabbitmq` image to `rabbitmq:3` across `integration_tests/assets/docker-compose.yml` and related override files, improving test environment reproducibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23ca24a85dae554a41e65641df70c644a8640a15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->