### PR TITLE
ITEM-390 WAZO 2117 configured reverse timeout not effective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 26.07
+
+* `POST /0.1/profiles` and `PUT /0.1/profiles/<profile_uuid>`
+  * service configurations are now strictly validated; previously unrecognized fields were silently accepted:
+    * unknown keys in a service configuration now return a `400` error;
+    * the `options` field is now validated against a schema; unknown options now return a `400` error;
+    * the `timeout` option, when provided, must be a number strictly greater than `0`;
+
 ## 26.02
 
 * `POST` and `PATCH` request bodies to endpoints accepting JSON payload are systematically parsed as JSON, with or without a proper `Content-Type` header;

--- a/alembic/versions/5a67556fbbf1_migrate_profile_service_timeout_to_.py
+++ b/alembic/versions/5a67556fbbf1_migrate_profile_service_timeout_to_.py
@@ -28,9 +28,10 @@ def upgrade():
         if not isinstance(config, dict) or 'timeout' not in config:
             continue
         top_level_timeout = config.pop('timeout')
-        options = config.setdefault('options', {})
+        options = config.get('options') or {}
         if 'timeout' not in options:
             options['timeout'] = top_level_timeout
+        config['options'] = options
         conn.execute(
             sa.update(_table).where(_table.c.uuid == row.uuid).values(config=config)
         )

--- a/alembic/versions/5a67556fbbf1_migrate_profile_service_timeout_to_.py
+++ b/alembic/versions/5a67556fbbf1_migrate_profile_service_timeout_to_.py
@@ -27,7 +27,7 @@ def upgrade():
         config = row.config
         if not isinstance(config, dict) or 'timeout' not in config:
             continue
-        top_level_timeout = config.pop('timeout')
+        top_level_timeout = config.pop('timeout', None)
         options = config.get('options') or {}
         if 'timeout' not in options:
             options['timeout'] = top_level_timeout

--- a/alembic/versions/5a67556fbbf1_migrate_profile_service_timeout_to_.py
+++ b/alembic/versions/5a67556fbbf1_migrate_profile_service_timeout_to_.py
@@ -1,0 +1,40 @@
+"""migrate_profile_service_timeout_to_options
+
+Revision ID: 5a67556fbbf1
+Revises: 2adc8aff56ea
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '5a67556fbbf1'
+down_revision = '2adc8aff56ea'
+
+_table = sa.table(
+    'dird_profile_service',
+    sa.column('uuid', sa.String),
+    sa.column('config', sa.JSON),
+)
+
+
+def upgrade():
+    conn = op.get_bind()
+    rows = conn.execute(sa.select(_table)).fetchall()
+    for row in rows:
+        config = row.config
+        if not isinstance(config, dict) or 'timeout' not in config:
+            continue
+        top_level_timeout = config.pop('timeout')
+        options = config.setdefault('options', {})
+        if 'timeout' not in options:
+            options['timeout'] = top_level_timeout
+        conn.execute(
+            sa.update(_table).where(_table.c.uuid == row.uuid).values(config=config)
+        )
+
+
+def downgrade():
+    pass

--- a/integration_tests/assets/docker-compose.reverse_timeout.override.yml
+++ b/integration_tests/assets/docker-compose.reverse_timeout.override.yml
@@ -1,0 +1,16 @@
+services:
+  sync:
+    depends_on:
+      - auth
+      - dird
+      - db
+      - ws
+    environment:
+      TARGETS: "dird:9489 auth:9497 db:5432 ws:9485"
+  ws:
+    image: wazoplatform/wazo-dird-ws-mock:local
+    ports:
+      - "9485"
+    volumes:
+      - "./scripts/asset.reverse_timeout.slow_ws.py:/tmp/ws.py"
+    command: "python3 /tmp/ws.py"

--- a/integration_tests/assets/scripts/asset.reverse_timeout.slow_ws.py
+++ b/integration_tests/assets/scripts/asset.reverse_timeout.slow_ws.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import time
+
+from flask import Flask, Response
+
+app = Flask(__name__)
+
+DELAY = 2.0
+NUMBER = '5551234567'
+FIRSTNAME = 'Alice'
+LASTNAME = 'Timeout'
+
+
+@app.route('/ws')
+def ws():
+    time.sleep(DELAY)
+
+    def generate():
+        yield 'number,firstname,lastname\n'
+        yield f'{NUMBER},{FIRSTNAME},{LASTNAME}\n'
+
+    return Response(generate(), content_type='text/csv; charset=utf-8')
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=9485)

--- a/integration_tests/suite/test_reverse_timeout.py
+++ b/integration_tests/suite/test_reverse_timeout.py
@@ -1,0 +1,77 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from hamcrest import assert_that, equal_to, none, not_
+
+from .helpers.base import BaseDirdIntegrationTest
+from .helpers.config import Config
+from .helpers.constants import VALID_UUID
+
+_SLOW_WS_NUMBER = '5551234567'
+_SLOW_WS_URL = 'http://ws:9485/ws'
+
+_DEFAULT_DISPLAY = {
+    'name': 'default_display',
+    'columns': [
+        {'title': 'Firstname', 'field': 'firstname'},
+        {'title': 'Lastname', 'field': 'lastname'},
+    ],
+}
+
+
+def new_reverse_timeout_config(Session):
+    config = Config(Session)
+    config.with_display(**_DEFAULT_DISPLAY)
+    config.with_source(
+        backend='csv_ws',
+        name='slow_ws',
+        lookup_url=_SLOW_WS_URL,
+        list_url=_SLOW_WS_URL,
+        first_matched_columns=['number'],
+        format_columns={'reverse': '{firstname} {lastname}'},
+    )
+    config.with_profile(
+        name='reverse-short-timeout',
+        display='default_display',
+        services={
+            'reverse': {
+                'sources': ['slow_ws'],
+                'options': {'timeout': 0.1},
+            }
+        },
+    )
+    config.with_profile(
+        name='reverse-long-timeout',
+        display='default_display',
+        services={
+            'reverse': {
+                'sources': ['slow_ws'],
+                'options': {'timeout': 5},
+            }
+        },
+    )
+    return config
+
+
+class TestReverseServiceTimeout(BaseDirdIntegrationTest):
+    """
+    Verify that options.timeout on a reverse profile is honoured.
+
+    The 'ws' service sleeps 2s before responding. A profile with
+    options.timeout=0.1 must time out (return None); one with
+    options.timeout=5 must return the contact.
+    """
+
+    asset = 'reverse_timeout'
+    config_factory = new_reverse_timeout_config
+
+    def test_reverse_with_short_timeout_returns_no_result(self) -> None:
+        result = self.reverse(_SLOW_WS_NUMBER, 'reverse-short-timeout', VALID_UUID)
+
+        assert_that(result['display'], none())
+
+    def test_reverse_with_long_timeout_returns_contact(self) -> None:
+        result = self.reverse(_SLOW_WS_NUMBER, 'reverse-long-timeout', VALID_UUID)
+
+        assert_that(result['display'], not_(none()))
+        assert_that(result['display'], equal_to('Alice Timeout'))

--- a/wazo_dird/plugins/config_service/plugin.py
+++ b/wazo_dird/plugins/config_service/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -293,7 +293,7 @@ class Service:
             'services': {
                 'lookup': {'sources': sources},
                 'favorites': {'sources': sources},
-                'reverse': {'sources': sources, 'timeout': 0.5},
+                'reverse': {'sources': sources, 'options': {'timeout': 0.5}},
             },
         }
 

--- a/wazo_dird/plugins/config_service/tests/test_config_service.py
+++ b/wazo_dird/plugins/config_service/tests/test_config_service.py
@@ -1,23 +1,51 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 from unittest.mock import Mock
 from unittest.mock import sentinel as s
 
-from hamcrest import assert_that, equal_to
+from hamcrest import assert_that, equal_to, has_entries
 
 from ..plugin import Service
 
 
 class TestConfigService(unittest.TestCase):
     def test_that_get_config_returns_the_config(self):
-        tenant_crud = None
-        confd_client = None
-        service = Service(
-            s.original_config, Mock(), s.controller, tenant_crud, confd_client
-        )
+        service = Service(s.original_config, Mock(), s.controller, None, None)
 
         config = service.get_config()
 
         assert_that(config, equal_to(s.original_config))
+
+
+class TestAutoCreateProfile(unittest.TestCase):
+    def _make_service(self):
+        controller = Mock()
+        service = Service(
+            config={},
+            bus=Mock(),
+            controller=controller,
+            tenant_crud=Mock(),
+            confd_client=Mock(),
+        )
+        return service, controller
+
+    def test_auto_create_profile_puts_reverse_timeout_under_options(self):
+        service, controller = self._make_service()
+        profile_service = Mock()
+        controller.services.get.return_value = profile_service
+
+        service._auto_create_profile(
+            tenant_uuid='tenant-uuid',
+            name='mytenant',
+            display={'uuid': 'display-uuid'},
+            sources=[{'uuid': 'source-uuid'}],
+        )
+
+        (_, kwargs) = profile_service.create.call_args
+        reverse_config = kwargs['services']['reverse']
+        assert_that(
+            reverse_config,
+            has_entries(options=has_entries(timeout=0.5)),
+        )

--- a/wazo_dird/plugins/lookup_service/plugin.py
+++ b/wazo_dird/plugins/lookup_service/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -64,7 +64,7 @@ class _LookupService(helpers.BaseService):
 
         params = {'return_when': ALL_COMPLETED}
         service_config = self.get_service_config(profile_config)
-        timeout = service_config.get('timeout')
+        timeout = service_config.get('options', {}).get('timeout')
         if timeout:
             params['timeout'] = timeout
 

--- a/wazo_dird/plugins/lookup_service/plugin.py
+++ b/wazo_dird/plugins/lookup_service/plugin.py
@@ -64,7 +64,7 @@ class _LookupService(helpers.BaseService):
 
         params = {'return_when': ALL_COMPLETED}
         service_config = self.get_service_config(profile_config)
-        timeout = service_config.get('options', {}).get('timeout')
+        timeout = (service_config.get('options') or {}).get('timeout')
         if timeout:
             params['timeout'] = timeout
 

--- a/wazo_dird/plugins/lookup_service/tests/test_lookup.py
+++ b/wazo_dird/plugins/lookup_service/tests/test_lookup.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch, sentinel
 
 from hamcrest import assert_that, equal_to, none, not_
 
-from ..plugin import LookupServicePlugin
+from ..plugin import LookupServicePlugin, _LookupService
 
 
 class TestLookupServicePlugin(unittest.TestCase):
@@ -75,3 +75,24 @@ class TestLookupServicePlugin(unittest.TestCase):
         plugin.unload()
 
         MockedLookupService.return_value.stop.assert_called_once_with()
+
+
+def _make_lookup_service() -> _LookupService:
+    source_manager = Mock()
+    source_manager.get.return_value = None
+    return _LookupService(config={}, source_manager=source_manager, controller=Mock())
+
+
+class TestLookupNullOptions(unittest.TestCase):
+    @patch('wazo_dird.plugins.lookup_service.plugin.wait')
+    def test_null_options_does_not_crash(self, mock_wait):
+        mock_wait.return_value = ([], [])
+        service = _make_lookup_service()
+        profile = {
+            'name': 'test',
+            'services': {'lookup': {'sources': [], 'options': None}},
+        }
+
+        service.lookup(profile, 'tenant', 'alice', 'user-uuid')
+
+        mock_wait.assert_called_once()

--- a/wazo_dird/plugins/lookup_service/tests/test_lookup.py
+++ b/wazo_dird/plugins/lookup_service/tests/test_lookup.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
+from concurrent.futures import ALL_COMPLETED
 from unittest.mock import Mock, patch, sentinel
 
 from hamcrest import assert_that, equal_to, none, not_
@@ -95,4 +96,4 @@ class TestLookupNullOptions(unittest.TestCase):
 
         service.lookup(profile, 'tenant', 'alice', 'user-uuid')
 
-        mock_wait.assert_called_once()
+        mock_wait.assert_called_once_with([], return_when=ALL_COMPLETED)

--- a/wazo_dird/plugins/profiles/schemas.py
+++ b/wazo_dird/plugins/profiles/schemas.py
@@ -1,8 +1,9 @@
-# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from marshmallow import RAISE
 from xivo.mallow import fields
-from xivo.mallow.validate import Length
+from xivo.mallow.validate import Length, Range
 from xivo.mallow_helpers import ListSchema as _ListSchema
 
 from wazo_dird.schemas import BaseSchema
@@ -12,9 +13,18 @@ class ResourceSchema(BaseSchema):
     uuid = fields.UUID(required=True)
 
 
+class ServiceOptionsSchema(BaseSchema):
+    class Meta(BaseSchema.Meta):
+        unknown = RAISE
+
+    timeout = fields.Float(
+        load_default=None, allow_none=True, validate=Range(min=0, min_inclusive=False)
+    )
+
+
 class ServiceConfigSchema(BaseSchema):
     sources = fields.Nested(ResourceSchema, many=True, load_default=[])
-    options = fields.Dict(load_default={})
+    options = fields.Nested(ServiceOptionsSchema, load_default={})
 
 
 class ServiceDictSchema(fields.Nested):

--- a/wazo_dird/plugins/profiles/schemas.py
+++ b/wazo_dird/plugins/profiles/schemas.py
@@ -23,6 +23,9 @@ class ServiceOptionsSchema(BaseSchema):
 
 
 class ServiceConfigSchema(BaseSchema):
+    class Meta(BaseSchema.Meta):
+        unknown = RAISE
+
     sources = fields.Nested(ResourceSchema, many=True, load_default=[])
     options = fields.Nested(ServiceOptionsSchema, load_default={})
 

--- a/wazo_dird/plugins/profiles/tests/test_schemas.py
+++ b/wazo_dird/plugins/profiles/tests/test_schemas.py
@@ -6,44 +6,65 @@ from unittest import TestCase
 from hamcrest import assert_that, calling, has_entries, raises
 from marshmallow.exceptions import ValidationError
 
-from ..schemas import ServiceOptionsSchema
+from ..schemas import ServiceConfigSchema, ServiceOptionsSchema
 
-_schema = ServiceOptionsSchema()
+_options_schema = ServiceOptionsSchema()
+_config_schema = ServiceConfigSchema()
 
 
 class TestServiceOptionsSchema(TestCase):
     def test_empty_options_is_valid(self):
-        result = _schema.load({})
+        result = _options_schema.load({})
         assert_that(result, has_entries(timeout=None))
 
     def test_valid_timeout(self):
-        result = _schema.load({'timeout': 1.5})
+        result = _options_schema.load({'timeout': 1.5})
         assert_that(result, has_entries(timeout=1.5))
 
     def test_null_timeout_is_valid(self):
-        result = _schema.load({'timeout': None})
+        result = _options_schema.load({'timeout': None})
         assert_that(result, has_entries(timeout=None))
 
     def test_zero_timeout_raises(self):
         assert_that(
-            calling(_schema.load).with_args({'timeout': 0}),
+            calling(_options_schema.load).with_args({'timeout': 0}),
             raises(ValidationError),
         )
 
     def test_negative_timeout_raises(self):
         assert_that(
-            calling(_schema.load).with_args({'timeout': -1}),
+            calling(_options_schema.load).with_args({'timeout': -1}),
             raises(ValidationError),
         )
 
     def test_unknown_key_raises(self):
         assert_that(
-            calling(_schema.load).with_args({'tiemout': 1}),
+            calling(_options_schema.load).with_args({'tiemout': 1}),
             raises(ValidationError),
         )
 
     def test_unknown_key_alongside_valid_key_raises(self):
         assert_that(
-            calling(_schema.load).with_args({'timeout': 1, 'unknown': 'value'}),
+            calling(_options_schema.load).with_args({'timeout': 1, 'unknown': 'value'}),
+            raises(ValidationError),
+        )
+
+
+class TestServiceConfigSchema(TestCase):
+    def test_valid_config(self):
+        result = _config_schema.load({'sources': [], 'options': {}})
+        assert_that(result, has_entries(sources=[], options=has_entries(timeout=None)))
+
+    def test_unknown_key_raises(self):
+        assert_that(
+            calling(_config_schema.load).with_args({'sources': [], 'timeout': 1}),
+            raises(ValidationError),
+        )
+
+    def test_unknown_key_alongside_valid_keys_raises(self):
+        assert_that(
+            calling(_config_schema.load).with_args(
+                {'sources': [], 'options': {}, 'extra': 'value'}
+            ),
             raises(ValidationError),
         )

--- a/wazo_dird/plugins/profiles/tests/test_schemas.py
+++ b/wazo_dird/plugins/profiles/tests/test_schemas.py
@@ -1,0 +1,49 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest import TestCase
+
+from hamcrest import assert_that, calling, has_entries, raises
+from marshmallow.exceptions import ValidationError
+
+from ..schemas import ServiceOptionsSchema
+
+_schema = ServiceOptionsSchema()
+
+
+class TestServiceOptionsSchema(TestCase):
+    def test_empty_options_is_valid(self):
+        result = _schema.load({})
+        assert_that(result, has_entries(timeout=None))
+
+    def test_valid_timeout(self):
+        result = _schema.load({'timeout': 1.5})
+        assert_that(result, has_entries(timeout=1.5))
+
+    def test_null_timeout_is_valid(self):
+        result = _schema.load({'timeout': None})
+        assert_that(result, has_entries(timeout=None))
+
+    def test_zero_timeout_raises(self):
+        assert_that(
+            calling(_schema.load).with_args({'timeout': 0}),
+            raises(ValidationError),
+        )
+
+    def test_negative_timeout_raises(self):
+        assert_that(
+            calling(_schema.load).with_args({'timeout': -1}),
+            raises(ValidationError),
+        )
+
+    def test_unknown_key_raises(self):
+        assert_that(
+            calling(_schema.load).with_args({'tiemout': 1}),
+            raises(ValidationError),
+        )
+
+    def test_unknown_key_alongside_valid_key_raises(self):
+        assert_that(
+            calling(_schema.load).with_args({'timeout': 1, 'unknown': 'value'}),
+            raises(ValidationError),
+        )

--- a/wazo_dird/plugins/reverse_service/plugin.py
+++ b/wazo_dird/plugins/reverse_service/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -64,7 +64,7 @@ class _ReverseService(helpers.BaseService):
 
         params = {}
         service_config = self.get_service_config(profile_config)
-        timeout = service_config.get('timeout')
+        timeout = service_config.get('options', {}).get('timeout', 1)
         if timeout:
             params['timeout'] = timeout
 
@@ -109,7 +109,7 @@ class _ReverseService(helpers.BaseService):
 
         params = {}
         service_config = self.get_service_config(profile_config)
-        timeout = service_config.get('timeout')
+        timeout = service_config.get('options', {}).get('timeout', 1)
         if timeout:
             params['timeout'] = timeout
 

--- a/wazo_dird/plugins/reverse_service/plugin.py
+++ b/wazo_dird/plugins/reverse_service/plugin.py
@@ -62,15 +62,12 @@ class _ReverseService(helpers.BaseService):
             args['xivo_user_uuid'] = user_uuid
             futures.append(self._async_reverse_many(source, extens, args))
 
-        params = {}
         service_config = self.get_service_config(profile_config)
-        timeout = service_config.get('options', {}).get('timeout', 1)
-        if timeout:
-            params['timeout'] = timeout
+        timeout = (service_config.get('options') or {}).get('timeout') or 1
 
         results = {exten: None for exten in extens}
         try:
-            for future in as_completed(futures, **params):
+            for future in as_completed(futures, timeout=timeout):
                 if result := future.result():
                     results.update(result)
                     if all(result is not None for result in results.values()):
@@ -128,14 +125,11 @@ class _ReverseService(helpers.BaseService):
             args['xivo_user_uuid'] = user_uuid
             futures.append(self._async_reverse(source, exten, args))
 
-        params = {}
         service_config = self.get_service_config(profile_config)
-        timeout = service_config.get('options', {}).get('timeout', 1)
-        if timeout:
-            params['timeout'] = timeout
+        timeout = (service_config.get('options') or {}).get('timeout') or 1
 
         try:
-            for future in as_completed(futures, **params):
+            for future in as_completed(futures, timeout=timeout):
                 if result := future.result():
                     pending_futures = [f for f in futures if not f.done()]
                     cancelled_futures = sum(1 for f in pending_futures if f.cancel())

--- a/wazo_dird/plugins/reverse_service/plugin.py
+++ b/wazo_dird/plugins/reverse_service/plugin.py
@@ -71,14 +71,35 @@ class _ReverseService(helpers.BaseService):
         results = {exten: None for exten in extens}
         try:
             for future in as_completed(futures, **params):
-                if future.result():
-                    results.update(future.result())
+                if result := future.result():
+                    results.update(result)
                     if all(result is not None for result in results.values()):
-                        for other_future in futures:
-                            other_future.cancel()
+                        pending_futures = [
+                            future for future in futures if not future.done()
+                        ]
+                        cancelled_futures = sum(
+                            1 for future in pending_futures if future.cancel()
+                        )
+                        logger.debug(
+                            'Cancelled %d/%d pending reverse lookup tasks',
+                            cancelled_futures,
+                            len(pending_futures),
+                        )
                         break
         except TimeoutError:
-            logger.info('Timeout on reverse many lookup for extens: %s', extens)
+            logger.warning(
+                'Timeout on reverse many lookup, returning partial results (extens=%s)',
+                extens,
+            )
+            cancelled_futures = 0
+            for future in futures:
+                if not future.done() and future.cancel():
+                    cancelled_futures += 1
+            logger.debug(
+                'Timeout: cancelled %d/%d reverse lookup tasks',
+                cancelled_futures,
+                len(futures),
+            )
         return [value for value in results.values()]
 
     def _async_reverse_many(self, source, extens, args):
@@ -115,12 +136,21 @@ class _ReverseService(helpers.BaseService):
 
         try:
             for future in as_completed(futures, **params):
-                if future.result() is not None:
-                    for other_future in futures:
-                        other_future.cancel()
-                    return future.result()
+                if result := future.result():
+                    pending_futures = [f for f in futures if not f.done()]
+                    cancelled_futures = sum(1 for f in pending_futures if f.cancel())
+                    logger.debug(
+                        'Cancelled %d/%d pending reverse lookup tasks',
+                        cancelled_futures,
+                        len(pending_futures),
+                    )
+                    return result
         except TimeoutError:
-            logger.info('Timeout on reverse lookup for exten: %s', exten)
+            logger.warning('Timeout on reverse lookup for exten: %s', exten)
+            cancelled_futures = sum(1 for f in futures if not f.done() and f.cancel())
+            logger.debug(
+                'cancelled %d/%d reverse lookup tasks', cancelled_futures, len(futures)
+            )
 
     def _async_reverse(self, source, exten, args):
         raise_stopper = helpers.RaiseStopper(return_on_raise=None)

--- a/wazo_dird/plugins/reverse_service/tests/test_reverse.py
+++ b/wazo_dird/plugins/reverse_service/tests/test_reverse.py
@@ -102,3 +102,27 @@ class TestReverseTimeout(unittest.TestCase):
         service.reverse_many(_PROFILE_WITH_TOPLEVEL_TIMEOUT, ['1234'], 'test')
 
         mock_as_completed.assert_called_once_with([], timeout=1)
+
+    @patch('wazo_dird.plugins.reverse_service.plugin.as_completed')
+    def test_reverse_cancels_pending_on_timeout(self, mock_as_completed):
+        mock_as_completed.side_effect = TimeoutError
+        future = Mock()
+        future.done.return_value = False
+        service, _ = _make_service_with_source()
+        service._executor.submit = Mock(return_value=future)
+
+        service.reverse(_PROFILE_WITH_SOURCE, '1234', 'test')
+
+        future.cancel.assert_called_once()
+
+    @patch('wazo_dird.plugins.reverse_service.plugin.as_completed')
+    def test_reverse_many_cancels_pending_on_timeout(self, mock_as_completed):
+        mock_as_completed.side_effect = TimeoutError
+        future = Mock()
+        future.done.return_value = False
+        service, _ = _make_service_with_source()
+        service._executor.submit = Mock(return_value=future)
+
+        service.reverse_many(_PROFILE_WITH_SOURCE, ['1234'], 'test')
+
+        future.cancel.assert_called_once()

--- a/wazo_dird/plugins/reverse_service/tests/test_reverse.py
+++ b/wazo_dird/plugins/reverse_service/tests/test_reverse.py
@@ -29,6 +29,16 @@ _PROFILE_WITH_TOPLEVEL_TIMEOUT = {
     'services': {'reverse': {'sources': [], 'timeout': 0.5}},
 }
 
+_PROFILE_WITH_NULL_OPTIONS = {
+    'name': 'test',
+    'services': {'reverse': {'sources': [], 'options': None}},
+}
+
+_PROFILE_WITH_ZERO_TIMEOUT = {
+    'name': 'test',
+    'services': {'reverse': {'sources': [], 'options': {'timeout': 0}}},
+}
+
 
 def _make_service() -> _ReverseService:
     source_manager = Mock()
@@ -100,6 +110,42 @@ class TestReverseTimeout(unittest.TestCase):
         service = _make_service()
 
         service.reverse_many(_PROFILE_WITH_TOPLEVEL_TIMEOUT, ['1234'], 'test')
+
+        mock_as_completed.assert_called_once_with([], timeout=1)
+
+    @patch('wazo_dird.plugins.reverse_service.plugin.as_completed')
+    def test_reverse_null_options_uses_default_timeout(self, mock_as_completed):
+        mock_as_completed.return_value = iter([])
+        service = _make_service()
+
+        service.reverse(_PROFILE_WITH_NULL_OPTIONS, '1234', 'test')
+
+        mock_as_completed.assert_called_once_with([], timeout=1)
+
+    @patch('wazo_dird.plugins.reverse_service.plugin.as_completed')
+    def test_reverse_many_null_options_uses_default_timeout(self, mock_as_completed):
+        mock_as_completed.return_value = iter([])
+        service = _make_service()
+
+        service.reverse_many(_PROFILE_WITH_NULL_OPTIONS, ['1234'], 'test')
+
+        mock_as_completed.assert_called_once_with([], timeout=1)
+
+    @patch('wazo_dird.plugins.reverse_service.plugin.as_completed')
+    def test_reverse_zero_timeout_uses_default(self, mock_as_completed):
+        mock_as_completed.return_value = iter([])
+        service = _make_service()
+
+        service.reverse(_PROFILE_WITH_ZERO_TIMEOUT, '1234', 'test')
+
+        mock_as_completed.assert_called_once_with([], timeout=1)
+
+    @patch('wazo_dird.plugins.reverse_service.plugin.as_completed')
+    def test_reverse_many_zero_timeout_uses_default(self, mock_as_completed):
+        mock_as_completed.return_value = iter([])
+        service = _make_service()
+
+        service.reverse_many(_PROFILE_WITH_ZERO_TIMEOUT, ['1234'], 'test')
 
         mock_as_completed.assert_called_once_with([], timeout=1)
 

--- a/wazo_dird/plugins/reverse_service/tests/test_reverse.py
+++ b/wazo_dird/plugins/reverse_service/tests/test_reverse.py
@@ -1,0 +1,104 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import unittest
+from unittest.mock import Mock, patch
+
+from ..plugin import _ReverseService
+
+_SOURCE_UUID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
+_PROFILE_NO_TIMEOUT = {
+    'name': 'test',
+    'services': {'reverse': {'sources': []}},
+}
+
+_PROFILE_WITH_SOURCE = {
+    'name': 'test',
+    'services': {'reverse': {'sources': [{'uuid': _SOURCE_UUID}]}},
+}
+
+_PROFILE_WITH_TIMEOUT = {
+    'name': 'test',
+    'services': {'reverse': {'sources': [], 'options': {'timeout': 0.5}}},
+}
+
+# timeout outside options is stripped by the profile schema (EXCLUDE unknown fields)
+_PROFILE_WITH_TOPLEVEL_TIMEOUT = {
+    'name': 'test',
+    'services': {'reverse': {'sources': [], 'timeout': 0.5}},
+}
+
+
+def _make_service() -> _ReverseService:
+    source_manager = Mock()
+    source_manager.get.return_value = None
+    return _ReverseService(config={}, source_manager=source_manager, controller=Mock())
+
+
+def _make_service_with_source() -> tuple[_ReverseService, Mock]:
+    source = Mock()
+    source_manager = Mock()
+    source_manager.get.return_value = source
+    service = _ReverseService(
+        config={}, source_manager=source_manager, controller=Mock()
+    )
+    return service, source
+
+
+class TestReverseTimeout(unittest.TestCase):
+    @patch('wazo_dird.plugins.reverse_service.plugin.as_completed')
+    def test_reverse_default_timeout(self, mock_as_completed):
+        mock_as_completed.return_value = iter([])
+        service = _make_service()
+
+        service.reverse(_PROFILE_NO_TIMEOUT, '1234', 'test')
+
+        mock_as_completed.assert_called_once_with([], timeout=1)
+
+    @patch('wazo_dird.plugins.reverse_service.plugin.as_completed')
+    def test_reverse_explicit_timeout_overrides_default(self, mock_as_completed):
+        mock_as_completed.return_value = iter([])
+        service = _make_service()
+
+        service.reverse(_PROFILE_WITH_TIMEOUT, '1234', 'test')
+
+        mock_as_completed.assert_called_once_with([], timeout=0.5)
+
+    @patch('wazo_dird.plugins.reverse_service.plugin.as_completed')
+    def test_reverse_many_default_timeout(self, mock_as_completed):
+        mock_as_completed.return_value = iter([])
+        service = _make_service()
+
+        service.reverse_many(_PROFILE_NO_TIMEOUT, ['1234'], 'test')
+
+        mock_as_completed.assert_called_once_with([], timeout=1)
+
+    @patch('wazo_dird.plugins.reverse_service.plugin.as_completed')
+    def test_reverse_many_explicit_timeout_overrides_default(self, mock_as_completed):
+        mock_as_completed.return_value = iter([])
+        service = _make_service()
+
+        service.reverse_many(_PROFILE_WITH_TIMEOUT, ['1234'], 'test')
+
+        mock_as_completed.assert_called_once_with([], timeout=0.5)
+
+    @patch('wazo_dird.plugins.reverse_service.plugin.as_completed')
+    def test_reverse_toplevel_timeout_is_ignored(self, mock_as_completed):
+        # timeout not nested under options is stripped by the profile API schema;
+        # the service must fall back to the default rather than silently using it
+        mock_as_completed.return_value = iter([])
+        service = _make_service()
+
+        service.reverse(_PROFILE_WITH_TOPLEVEL_TIMEOUT, '1234', 'test')
+
+        mock_as_completed.assert_called_once_with([], timeout=1)
+
+    @patch('wazo_dird.plugins.reverse_service.plugin.as_completed')
+    def test_reverse_many_toplevel_timeout_is_ignored(self, mock_as_completed):
+        mock_as_completed.return_value = iter([])
+        service = _make_service()
+
+        service.reverse_many(_PROFILE_WITH_TOPLEVEL_TIMEOUT, ['1234'], 'test')
+
+        mock_as_completed.assert_called_once_with([], timeout=1)

--- a/wazo_dird/plugins/reverse_service/tests/test_reverse.py
+++ b/wazo_dird/plugins/reverse_service/tests/test_reverse.py
@@ -23,7 +23,7 @@ _PROFILE_WITH_TIMEOUT = {
     'services': {'reverse': {'sources': [], 'options': {'timeout': 0.5}}},
 }
 
-# timeout outside options is stripped by the profile schema (EXCLUDE unknown fields)
+# timeout outside options is rejected by the profile schema (RAISE on unknown fields)
 _PROFILE_WITH_TOPLEVEL_TIMEOUT = {
     'name': 'test',
     'services': {'reverse': {'sources': [], 'timeout': 0.5}},


### PR DESCRIPTION
## suggested test protocol

- [x] prior: verify that changing timeout option in profile through API is not effective (e.g. set to 0.01 to ensure reverse lookup should timeout systematically)
- [x] prior: verify that database has top-level `timeout` keys in default profile with `select name, config from dird_profile_service join dird_profile on dird_profile.uuid = dird_profile_service.profile_uuid ;`
- [x] mount PR 
  - [x] run database migrations (`xivo-upgrade-db`); verify that database now has config updated  with `timeout` in `options` sub-object
  - [x] change default profile timeout through API and verify that new value is effective
  - [ ] setting timeout to 0 or `null` yields error
  - [x] same works for lookup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes directory lookup/reverse timing and rejects previously accepted profile JSON shapes; deploy requires DB migration for existing timeout values.
> 
> **Overview**
> Fixes profile **reverse** (and **lookup**) timeouts so `options.timeout` is actually applied instead of a ignored top-level `timeout` field.
> 
> **Runtime:** reverse and lookup read timeout from `services.<name>.options.timeout`. Reverse always passes a timeout to `as_completed` (default **1s** when unset), cancels pending futures on timeout or early success, and logs timeouts at warning level. Auto-created tenant profiles now set `options: { timeout: 0.5 }` for reverse.
> 
> **API & data:** `POST`/`PUT` profile payloads strictly validate each service block and `options` (unknown keys → **400**; `timeout` must be **> 0** when set). An Alembic migration moves existing `dird_profile_service.config.timeout` into `config.options.timeout`.
> 
> **Tests:** unit tests for schemas and timeout behaviour, plus integration coverage with a slow CSV-WS source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45da2b093dd25e457a4b5827d7dfe61ea6ee6d46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->