### PR TITLE
ITEM-376 configurable threadpools

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -94,6 +94,9 @@ class DBRunningTestCase(DirdAssetRunningTestCase):
     @classmethod
     def restart_dird(cls):
         cls.restart_service('dird')
+        # The published host port may change across a container restart; refresh
+        # the cached value so url()/get_client() stay consistent with cls.dird.
+        cls.port = cls.service_port(9489, 'dird')
         cls.dird = cls.make_dird(VALID_TOKEN_MAIN_TENANT)
 
     @classmethod

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -94,8 +94,6 @@ class DBRunningTestCase(DirdAssetRunningTestCase):
     @classmethod
     def restart_dird(cls):
         cls.restart_service('dird')
-        # The published host port may change across a container restart; refresh
-        # the cached value so url()/get_client() stay consistent with cls.dird.
         cls.port = cls.service_port(9489, 'dird')
         cls.dird = cls.make_dird(VALID_TOKEN_MAIN_TENANT)
 

--- a/integration_tests/suite/test_core_functionality.py
+++ b/integration_tests/suite/test_core_functionality.py
@@ -1,6 +1,7 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 from hamcrest import (
@@ -94,6 +95,17 @@ class TestCoreSourceManagement(BaseMultipleSourceLauncher):
             result['results'], contains_inanyorder(self.alice_aaa, self.alice_alan)
         )
 
+    def test_lookup_with_configured_executor_workers(self):
+        with self.dird_with_config({'lookup_service': {'executor_workers': 2}}):
+            self.wait_strategy.wait(self.dird)
+            with ThreadPoolExecutor(max_workers=5) as pool:
+                futures = [
+                    pool.submit(self.lookup, 'lice', 'default') for _ in range(5)
+                ]
+                results = [f.result() for f in futures]
+        for result in results:
+            assert_that(result['results'], has_length(2))
+
 
 class TestReverse(BaseMultipleSourceLauncher):
     def setUp(self):
@@ -171,6 +183,21 @@ class TestReverse(BaseMultipleSourceLauncher):
         }
 
         assert_that(result, equal_to(expected))
+
+    def test_reverse_with_configured_executor_workers(self):
+        with self.dird_with_config({'reverse_service': {'executor_workers': 2}}):
+            self.wait_strategy.wait(self.dird)
+            with ThreadPoolExecutor(max_workers=5) as pool:
+                futures = [
+                    pool.submit(self.reverse, '1111', 'default', VALID_UUID)
+                    for _ in range(5)
+                ]
+                results = [f.result() for f in futures]
+        for result in results:
+            assert_that(
+                result,
+                any_of(self.alice_result, self.qwerty_result_1, self.qwerty_result_2),
+            )
 
 
 class TestLookupWhenASourceFails(HalfBrokenTestCase):

--- a/integration_tests/suite/test_favorites.py
+++ b/integration_tests/suite/test_favorites.py
@@ -1,7 +1,8 @@
-# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 
 from hamcrest import (
     any_of,
@@ -160,6 +161,26 @@ class TestFavorites(_BaseMultiTokenFavoriteTest):
                 has_entry('column_values', contains('Bob', 'BBB', '5555551234', True)),
             ),
         )
+
+    def test_favorites_with_configured_executor_workers(self):
+        with self.favorite('my_csv', '1', token=self.token_1):
+            with self.dird_with_config({'favorites_service': {'executor_workers': 2}}):
+                self.wait_strategy.wait(self.dird)
+                with ThreadPoolExecutor(max_workers=5) as pool:
+                    futures = [
+                        pool.submit(self.favorites, 'default', token=self.token_1)
+                        for _ in range(5)
+                    ]
+                    results = [f.result() for f in futures]
+        for result in results:
+            assert_that(
+                result['results'],
+                contains_inanyorder(
+                    has_entry(
+                        'column_values', contains('Alice', 'AAA', '5555555555', True)
+                    )
+                ),
+            )
 
 
 class TestRemovingFavoriteAlreadyInexistant(CSVWithMultipleDisplayTestCase):

--- a/wazo_dird/config.py
+++ b/wazo_dird/config.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -79,6 +79,18 @@ class ConsulConfig(TypedDict):
     port: int
 
 
+class ReverseServiceConfig(TypedDict, total=False):
+    executor_workers: int
+
+
+class LookupServiceConfig(TypedDict, total=False):
+    executor_workers: int
+
+
+class FavoritesServiceConfig(TypedDict, total=False):
+    executor_workers: int
+
+
 class Config(TypedDict, total=False):
     uuid: str
     auth: AuthConfig
@@ -92,6 +104,9 @@ class Config(TypedDict, total=False):
     log_filename: str
     rest_api: RestAPIConfig
     services: dict[str, dict[str, Any]]
+    reverse_service: ReverseServiceConfig
+    lookup_service: LookupServiceConfig
+    favorites_service: FavoritesServiceConfig
     user: str
     bus: BusConfig
     consul: ConsulConfig

--- a/wazo_dird/config.py
+++ b/wazo_dird/config.py
@@ -80,15 +80,15 @@ class ConsulConfig(TypedDict):
 
 
 class ReverseServiceConfig(TypedDict, total=False):
-    executor_workers: int
+    executor_workers: int | None
 
 
 class LookupServiceConfig(TypedDict, total=False):
-    executor_workers: int
+    executor_workers: int | None
 
 
 class FavoritesServiceConfig(TypedDict, total=False):
-    executor_workers: int
+    executor_workers: int | None
 
 
 class Config(TypedDict, total=False):
@@ -194,6 +194,15 @@ _DEFAULT_CONFIG: Config = {
             'allow_headers': ['Content-Type', 'X-Auth-Token', 'Wazo-Tenant'],
         },
         'max_threads': 10,
+    },
+    'reverse_service': {
+        'executor_workers': None,  # None: inherit rest_api.max_threads
+    },
+    'lookup_service': {
+        'executor_workers': None,  # None: inherit rest_api.max_threads
+    },
+    'favorites_service': {
+        'executor_workers': None,  # None: inherit rest_api.max_threads
     },
     'services': {
         'service_discovery': {

--- a/wazo_dird/plugins/favorites_service/plugin.py
+++ b/wazo_dird/plugins/favorites_service/plugin.py
@@ -87,9 +87,8 @@ class _FavoritesService(helpers.BaseService):
     ) -> None:
         super().__init__(config, source_manager, controller)
         http_threads = config.get('rest_api', {}).get('max_threads', 10)
-        max_workers = config.get('favorites_service', {}).get(
-            'executor_workers', http_threads
-        )
+        executor_workers = config.get('favorites_service', {}).get('executor_workers')
+        max_workers = executor_workers if executor_workers is not None else http_threads
         logger.info(
             'Creating favorites service threadpool [max_workers=%d]', max_workers
         )

--- a/wazo_dird/plugins/favorites_service/plugin.py
+++ b/wazo_dird/plugins/favorites_service/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -85,13 +85,18 @@ class _FavoritesService(helpers.BaseService):
         crud: database.FavoriteCRUD,
         bus: CoreBus,
     ) -> None:
-        super().__init__(config, source_manager, controller, crud, bus)
-        self._executor = ThreadPoolExecutor(max_workers=10)
+        super().__init__(config, source_manager, controller)
+        http_threads = config.get('rest_api', {}).get('max_threads', 10)
+        max_workers = config.get('favorites_service', {}).get(
+            'executor_workers', http_threads
+        )
+        logger.info(
+            'Creating favorites service threadpool [max_workers=%d]', max_workers
+        )
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
         self._crud = crud
         self._bus = bus
         self._xivo_uuid = config.get('uuid')
-        self._source_manager = source_manager
-        self._controller = controller
         if not self._xivo_uuid:
             logger.info('loaded without a UUID: published events will be incomplete')
 

--- a/wazo_dird/plugins/lookup_service/plugin.py
+++ b/wazo_dird/plugins/lookup_service/plugin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 from concurrent.futures import ALL_COMPLETED, Future, ThreadPoolExecutor, wait
+from time import perf_counter
 from typing import Any
 
 from wazo_dird import BaseServicePlugin, BaseSourcePlugin, helpers
@@ -13,6 +14,7 @@ from wazo_dird.plugin_manager import ServiceDependencies
 from wazo_dird.plugins.source_result import _SourceResult as SourceResult
 
 logger = logging.getLogger(__name__)
+timing_logger = logger.getChild('timing')
 
 
 class LookupServicePlugin(BaseServicePlugin):
@@ -62,9 +64,33 @@ class _LookupService(helpers.BaseService):
         raise_stopper: helpers.RaiseStopper[list[SourceResult]] = helpers.RaiseStopper(
             return_on_raise=[]
         )
-        future = self._executor.submit(raise_stopper.execute, source.search, term, args)
+        submitted_at = perf_counter()
+        future = self._executor.submit(
+            self._timed_search, raise_stopper, source, term, args, submitted_at
+        )
         setattr(future, 'name', source.name)
         return future
+
+    def _timed_search(
+        self,
+        raise_stopper: helpers.RaiseStopper[list[SourceResult]],
+        source: BaseSourcePlugin,
+        term: str,
+        args: dict[str, Any],
+        submitted_at: float,
+    ) -> list[SourceResult]:
+        started_at = perf_counter()
+        results = raise_stopper.execute(source.search, term, args)
+        finished_at = perf_counter()
+        timing_logger.debug(
+            'lookup source=%s backend=%s queue_ms=%.1f exec_ms=%.1f results=%d',
+            source.name,
+            source.backend,
+            (started_at - submitted_at) * 1000,
+            (finished_at - started_at) * 1000,
+            len(results),
+        )
+        return results
 
     def lookup(
         self,

--- a/wazo_dird/plugins/lookup_service/plugin.py
+++ b/wazo_dird/plugins/lookup_service/plugin.py
@@ -45,7 +45,12 @@ class _LookupService(helpers.BaseService):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self._executor = ThreadPoolExecutor(max_workers=10)
+        http_threads = self._config.get('rest_api', {}).get('max_threads', 10)
+        max_workers = self._config.get('lookup_service', {}).get(
+            'executor_workers', http_threads
+        )
+        logger.info('Creating Lookup service threadpool [max_workers=%d]', max_workers)
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
 
     def stop(self) -> None:
         self._executor.shutdown()

--- a/wazo_dird/plugins/lookup_service/plugin.py
+++ b/wazo_dird/plugins/lookup_service/plugin.py
@@ -46,9 +46,10 @@ class _LookupService(helpers.BaseService):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         http_threads = self._config.get('rest_api', {}).get('max_threads', 10)
-        max_workers = self._config.get('lookup_service', {}).get(
-            'executor_workers', http_threads
+        executor_workers = self._config.get('lookup_service', {}).get(
+            'executor_workers'
         )
+        max_workers = executor_workers if executor_workers is not None else http_threads
         logger.info('Creating Lookup service threadpool [max_workers=%d]', max_workers)
         self._executor = ThreadPoolExecutor(max_workers=max_workers)
 

--- a/wazo_dird/plugins/lookup_service/tests/test_lookup.py
+++ b/wazo_dird/plugins/lookup_service/tests/test_lookup.py
@@ -6,7 +6,7 @@ from concurrent.futures import ALL_COMPLETED
 from typing import cast
 from unittest.mock import Mock, patch, sentinel
 
-from hamcrest import assert_that, equal_to, none, not_
+from hamcrest import assert_that, contains_string, equal_to, none, not_
 
 from wazo_dird.helpers import ProfileConfig
 from wazo_dird.plugin_manager import ServiceDependencies
@@ -111,3 +111,39 @@ class TestLookupNullOptions(unittest.TestCase):
         service.lookup(cast(ProfileConfig, profile), 'tenant', 'alice', 'user-uuid')
 
         mock_wait.assert_called_once_with([], return_when=ALL_COMPLETED)
+
+
+TIMING_LOGGER = 'wazo_dird.plugins.lookup_service.plugin.timing'
+
+
+class TestLookupPerSourceTiming(unittest.TestCase):
+    def _service_with_source(self, source: Mock) -> _LookupService:
+        source_manager = Mock()
+        source_manager.get.return_value = source
+        return _LookupService(
+            config={}, source_manager=source_manager, controller=Mock()
+        )
+
+    def test_logs_queue_and_exec_time_per_source(self):
+        source = Mock()
+        source.name = 'my_ldap'
+        source.backend = 'ldap'
+        source.search.return_value = [sentinel.result1, sentinel.result2]
+        service = self._service_with_source(source)
+        profile = {
+            'name': 'test',
+            'services': {'lookup': {'sources': [{'uuid': 'src-uuid'}]}},
+        }
+
+        with self.assertLogs(TIMING_LOGGER, level='DEBUG') as logs:
+            results = service.lookup(
+                cast(ProfileConfig, profile), 'tenant', 'alice', 'user-uuid'
+            )
+
+        assert_that(results, equal_to([sentinel.result1, sentinel.result2]))
+        messages = [r.getMessage() for r in logs.records if 'my_ldap' in r.getMessage()]
+        assert_that(len(messages), equal_to(1))
+        assert_that(messages[0], contains_string('backend=ldap'))
+        assert_that(messages[0], contains_string('queue_ms='))
+        assert_that(messages[0], contains_string('exec_ms='))
+        assert_that(messages[0], contains_string('results=2'))

--- a/wazo_dird/plugins/reverse_service/plugin.py
+++ b/wazo_dird/plugins/reverse_service/plugin.py
@@ -46,9 +46,10 @@ class _ReverseService(helpers.BaseService):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         http_threads = self._config.get('rest_api', {}).get('max_threads', 10)
-        max_workers = self._config.get('reverse_service', {}).get(
-            'executor_workers', http_threads
+        executor_workers = self._config.get('reverse_service', {}).get(
+            'executor_workers'
         )
+        max_workers = executor_workers if executor_workers is not None else http_threads
         logger.info('Creating reverse service threadpool [max_workers=%d]', max_workers)
         self._executor = ThreadPoolExecutor(max_workers=max_workers)
 

--- a/wazo_dird/plugins/reverse_service/plugin.py
+++ b/wazo_dird/plugins/reverse_service/plugin.py
@@ -45,7 +45,12 @@ class _ReverseService(helpers.BaseService):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self._executor = ThreadPoolExecutor(max_workers=10)
+        http_threads = self._config.get('rest_api', {}).get('max_threads', 10)
+        max_workers = self._config.get('reverse_service', {}).get(
+            'executor_workers', http_threads
+        )
+        logger.info('Creating reverse service threadpool [max_workers=%d]', max_workers)
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
 
     def stop(self) -> None:
         self._executor.shutdown()


### PR DESCRIPTION
- **fix(threadpools): make threadpools max size configurable**
- **integration tests: test custom per-service threadpool config**
- **misc(contribs): stress tests with locust**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default concurrency wiring for core directory request paths; mis-tuned `executor_workers` could affect throughput or latency under load, though behavior stays backward-compatible when unset.
> 
> **Overview**
> Adds **`executor_workers`** under `lookup_service`, `reverse_service`, and `favorites_service` in config (default **`None`** → use **`rest_api.max_threads`**). Lookup, reverse, and favorites services now size their **`ThreadPoolExecutor`** from that setting and log the chosen pool size at startup.
> 
> Lookup additionally emits **DEBUG** per-source timing (`queue_ms`, `exec_ms`, result count) around parallel source searches.
> 
> Integration coverage reloads dird with a small pool (`executor_workers: 2`) and hammers lookup, reverse, and favorites concurrently; **`restart_dird`** refreshes the REST port after restart. Unit tests assert the lookup timing log format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db72159e47833e5d478845d780ca5c595263d3c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->