### PR TITLE
ITEM-391-typing-xivo-lib

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
         exclude: '^integration_tests/docker/broken-plugins/setup\.py$'
         language_version: "3.11"
         additional_dependencies:
+          - "marshmallow==3.18.0"
           - "types-jsonpatch"
           - "types-pyyaml"
           - "types-requests"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,12 +19,12 @@ repos:
         exclude: '^integration_tests/docker/broken-plugins/setup\.py$'
         language_version: "3.11"
         additional_dependencies:
-          - "types-requests"
-          - "types-pyyaml"
-          - "wazo_auth_client@https://github.com/wazo-platform/wazo-auth-client/archive/master.zip"
-          - "xivo@https://github.com/wazo-platform/xivo-lib-python/archive/master.zip"
-          - "wazo_bus@https://github.com/wazo-platform/wazo-bus/archive/master.zip"
           - "types-jsonpatch"
+          - "types-pyyaml"
+          - "types-requests"
+          - "wazo_auth_client@https://github.com/wazo-platform/wazo-auth-client/archive/master.zip"
+          - "wazo_bus@https://github.com/wazo-platform/wazo-bus/archive/master.zip"
+          - "xivo@https://github.com/wazo-platform/xivo-lib-python/archive/master.zip"
   # Automatically update to modern python (as modern as allowed by your Python version)
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.15.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,34 @@ disallow_untyped_calls = false
 # TODO: remove when py.typed markers are added to those libraries
 [[tool.mypy.overrides]]
 module = [
-    "wazo_auth_client",
-    "wazo_confd_client",
+    "wazo_auth_client.*",
+    "wazo_bus.*",
+    "wazo_confd_client.*",
+    "wazo_dird_client.*",
+    "wazo_test_helpers.*",
 ]
+ignore_missing_imports = true
+
+# Third-party libraries that ship no type information. CI omits their stubs and
+# relies on this override; without it a local checkout (where the libs are
+# installed but untyped) reports import-untyped noise that hides real errors.
+[[tool.mypy.overrides]]
+module = [
+    "flask_cors.*",
+    "flask_restful.*",
+    "graphene.*",
+    "graphql_server.*",
+    "ldap.*",
+    "mockserver.*",
+    "psycopg2.*",
+    "sqlalchemy.*",
+    "stevedore.*",
+]
+ignore_missing_imports = true
+
+# assert_that's invariant Matcher[T] can't unify with container matchers; skip
+# following hamcrest so assertions type as Any rather than erroring.
+[[tool.mypy.overrides]]
+module = ["hamcrest.*"]
+follow_imports = "skip"
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,9 +65,8 @@ module = [
 ]
 ignore_missing_imports = true
 
-# Third-party libraries that ship no type information. CI omits their stubs and
-# relies on this override; without it a local checkout (where the libs are
-# installed but untyped) reports import-untyped noise that hides real errors.
+# TODO: install the available stub packages (e.g. types-psycopg2,
+# sqlalchemy-stubs) in the pre-commit/mypy env so these overrides can be dropped.
 [[tool.mypy.overrides]]
 module = [
     "flask_cors.*",

--- a/wazo_dird/auth.py
+++ b/wazo_dird/auth.py
@@ -28,7 +28,7 @@ def set_auth_config(config: AuthConfig) -> None:
 def client() -> Client:
     global auth_client
     if not auth_client:
-        auth_client = Client(**auth_config)
+        auth_client = Client(**cast('AuthConfig', auth_config))
     return auth_client
 
 
@@ -37,7 +37,7 @@ Decorator = Callable[[F], F]
 
 
 def required_master_tenant() -> Decorator:
-    return required_tenant(master_tenant_uuid)
+    return required_tenant(cast(str, master_tenant_uuid))
 
 
 def init_master_tenant(token: dict[str, Any]) -> None:

--- a/wazo_dird/auth.py
+++ b/wazo_dird/auth.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -7,9 +7,7 @@ from typing import Any, TypeVar, cast
 
 from wazo_auth_client import Client
 from werkzeug.local import LocalProxy as Proxy
-from xivo.auth_verifier import no_auth as _no_auth
-from xivo.auth_verifier import required_acl as _required_acl
-from xivo.auth_verifier import required_tenant
+from xivo.auth_verifier import no_auth, required_acl, required_tenant
 from xivo.status import Status, StatusDict
 
 from .config import AuthConfig
@@ -38,27 +36,8 @@ F = TypeVar('F', bound=Callable[..., Any])
 Decorator = Callable[[F], F]
 
 
-# no_auth and required_acl come from the untyped xivo.auth_verifier module;
-# wrap them so decorated endpoints keep a typed signature.
-def no_auth(func: F) -> F:
-    return cast(F, _no_auth(func))
-
-
-def required_acl(
-    acl: str, *args: Any, **kwargs: Any
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    return cast(
-        'Callable[[Callable[..., Any]], Callable[..., Any]]',
-        _required_acl(acl, *args, **kwargs),
-    )
-
-
-def required_master_tenant() -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    # required_tenant comes from the untyped xivo.auth_verifier module
-    return cast(
-        'Callable[[Callable[..., Any]], Callable[..., Any]]',
-        required_tenant(master_tenant_uuid),
-    )
+def required_master_tenant() -> Decorator:
+    return required_tenant(master_tenant_uuid)
 
 
 def init_master_tenant(token: dict[str, Any]) -> None:

--- a/wazo_dird/controller.py
+++ b/wazo_dird/controller.py
@@ -54,7 +54,7 @@ class Controller:
         self.status_aggregator.add_provider(auth.provide_status)
         self._service_registration_params = (
             'wazo-dird',
-            self.config['uuid'],
+            self.config.get('uuid'),
             self.config['consul'],
             self.config['service_discovery'],
             self.config['bus'],

--- a/wazo_dird/controller.py
+++ b/wazo_dird/controller.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -8,6 +8,7 @@ import signal
 import threading
 from functools import partial
 from types import FrameType
+from typing import Any, cast
 
 from wazo_auth_client import Client as AuthClient
 from wazo_confd_client import Client as ConfdClient
@@ -52,14 +53,17 @@ class Controller:
         self.token_renewer.subscribe_to_token_change(self.confd_client.set_token)
         self.status_aggregator = StatusAggregator()
         self.status_aggregator.add_provider(auth.provide_status)
-        self._service_registration_params = [
+        # a tuple keeps a distinct type per position so it unpacks cleanly into
+        # ServiceCatalogRegistration; the config values are typed Optional/
+        # TypedDict but are concrete dicts at runtime.
+        self._service_registration_params = (
             'wazo-dird',
-            self.config.get('uuid'),
-            self.config.get('consul'),
-            self.config.get('service_discovery'),
-            self.config.get('bus'),
+            cast(str, self.config.get('uuid')),
+            cast('dict[str, Any]', self.config.get('consul')),
+            cast('dict[str, Any]', self.config.get('service_discovery')),
+            cast('dict[str, Any]', self.config.get('bus')),
             partial(self_check, self.config['rest_api']['port']),
-        ]
+        )
         self._source_manager = SourceManager(
             self.config['enabled_plugins']['backends'],
             self.config,

--- a/wazo_dird/controller.py
+++ b/wazo_dird/controller.py
@@ -8,7 +8,6 @@ import signal
 import threading
 from functools import partial
 from types import FrameType
-from typing import Any, cast
 
 from wazo_auth_client import Client as AuthClient
 from wazo_confd_client import Client as ConfdClient
@@ -53,15 +52,12 @@ class Controller:
         self.token_renewer.subscribe_to_token_change(self.confd_client.set_token)
         self.status_aggregator = StatusAggregator()
         self.status_aggregator.add_provider(auth.provide_status)
-        # a tuple keeps a distinct type per position so it unpacks cleanly into
-        # ServiceCatalogRegistration; the config values are typed Optional/
-        # TypedDict but are concrete dicts at runtime.
         self._service_registration_params = (
             'wazo-dird',
-            cast(str, self.config.get('uuid')),
-            cast('dict[str, Any]', self.config.get('consul')),
-            cast('dict[str, Any]', self.config.get('service_discovery')),
-            cast('dict[str, Any]', self.config.get('bus')),
+            self.config['uuid'],
+            self.config['consul'],
+            self.config['service_discovery'],
+            self.config['bus'],
             partial(self_check, self.config['rest_api']['port']),
         )
         self._source_manager = SourceManager(

--- a/wazo_dird/database/schemas.py
+++ b/wazo_dird/database/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -49,7 +49,9 @@ class ServiceSchema(BaseSchema):
 
 
 class ServiceDictSchema(fields.Nested):
-    def _serialize(
+    # marshmallow names _serialize's first arg "value" in Field but
+    # "nested_obj" in Nested; an override can't match both names.
+    def _serialize(  # type: ignore[override]
         self, value: Any, attr: str | None, obj: Any, **kwargs: Any
     ) -> dict[str, Any] | None:
         if value is None:

--- a/wazo_dird/http.py
+++ b/wazo_dird/http.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -7,8 +7,9 @@ import logging
 import time
 from collections.abc import Callable
 from functools import wraps
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar, cast, overload
 
+from flask import request
 from flask_restful import Resource
 from xivo import mallow_helpers, rest_api_helpers
 from xivo.flask.auth_verifier import AuthVerifierFlask
@@ -18,6 +19,26 @@ R = TypeVar('R')
 logger = logging.getLogger(__name__)
 
 auth_verifier = AuthVerifierFlask()
+
+
+@overload
+def get_json_body(many: Literal[False] = False) -> dict[str, Any]:
+    ...
+
+
+@overload
+def get_json_body(many: Literal[True]) -> list[dict[str, Any]]:
+    ...
+
+
+def get_json_body(many: bool = False) -> dict[str, Any] | list[dict[str, Any]]:
+    # get_json(force=True) raises on a missing/invalid body, so it never
+    # returns None at runtime; Flask's stub types it as Any | None regardless.
+    # `many` mirrors marshmallow: a JSON array body deserializes to a list.
+    body = request.get_json(force=True)
+    if many:
+        return cast('list[dict[str, Any]]', body)
+    return cast('dict[str, Any]', body)
 
 
 def handle_api_exception(

--- a/wazo_dird/http.py
+++ b/wazo_dird/http.py
@@ -22,10 +22,12 @@ auth_verifier = AuthVerifierFlask()
 
 
 def get_json_body() -> Any:
-    # get_json(force=True) raises on a missing/invalid body, so it never
-    # returns None at runtime; Flask's stub types it as Any | None regardless.
+    # get_json(force=True) raises 400 on a missing/invalid body but returns
+    # None for a literal `null` payload; reject that as a 400 so the return is
+    # genuinely non-None (Flask's stub types it as Any | None).
     body = request.get_json(force=True)
-    assert body is not None
+    if body is None:
+        raise rest_api_helpers.APIException(400, 'invalid data', 'invalid-data')
     return body
 
 

--- a/wazo_dird/http.py
+++ b/wazo_dird/http.py
@@ -7,7 +7,7 @@ import logging
 import time
 from collections.abc import Callable
 from functools import wraps
-from typing import Any, Literal, TypeVar, cast, overload
+from typing import Any, TypeVar
 
 from flask import request
 from flask_restful import Resource
@@ -21,24 +21,12 @@ logger = logging.getLogger(__name__)
 auth_verifier = AuthVerifierFlask()
 
 
-@overload
-def get_json_body(many: Literal[False] = False) -> dict[str, Any]:
-    ...
-
-
-@overload
-def get_json_body(many: Literal[True]) -> list[dict[str, Any]]:
-    ...
-
-
-def get_json_body(many: bool = False) -> dict[str, Any] | list[dict[str, Any]]:
+def get_json_body() -> Any:
     # get_json(force=True) raises on a missing/invalid body, so it never
     # returns None at runtime; Flask's stub types it as Any | None regardless.
-    # `many` mirrors marshmallow: a JSON array body deserializes to a list.
     body = request.get_json(force=True)
-    if many:
-        return cast('list[dict[str, Any]]', body)
-    return cast('dict[str, Any]', body)
+    assert body is not None
+    return body
 
 
 def handle_api_exception(

--- a/wazo_dird/main.py
+++ b/wazo_dird/main.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -7,12 +7,13 @@ import logging
 import sys
 from collections.abc import Sequence
 from types import TracebackType
-from typing import Any
+from typing import Any, cast
 
 from xivo import xivo_logging
 from xivo.config_helper import UUIDNotFound, set_xivo_uuid
 from xivo.user_rights import change_user
 
+from wazo_dird.config import Config
 from wazo_dird.config import load as load_config
 from wazo_dird.controller import Controller
 
@@ -58,8 +59,8 @@ class _PreConfigLogger:
 
 def main(argv: Sequence[str] | None = None) -> None:
     argv = argv or sys.argv[1:]
-    with _PreConfigLogger() as logger:
-        logger.debug('Starting wazo-dird')
+    with _PreConfigLogger() as startup_logger:
+        startup_logger.debug('Starting wazo-dird')
 
         config = load_config(argv)
 
@@ -81,5 +82,6 @@ def main(argv: Sequence[str] | None = None) -> None:
         if config['service_discovery']['enabled']:
             raise
 
-    controller = Controller(config)
+    # set_xivo_uuid has filled in 'uuid'; the merged mapping is now a Config
+    controller = Controller(cast('Config', config))
     controller.run()

--- a/wazo_dird/plugins/conference_backend/schemas.py
+++ b/wazo_dird/plugins/conference_backend/schemas.py
@@ -18,8 +18,8 @@ from wazo_dird.schemas import (
 
 
 class ExtensionSchema(BaseSchema):
-    # "context" shadows marshmallow's Schema.context attribute (a dict)
-    context = fields.String()  # type: ignore[assignment]
+    # context_ avoids shadowing marshmallow's Schema.context; key stays "context"
+    context_ = fields.String(attribute='context', data_key='context')
     exten = fields.String()
 
 

--- a/wazo_dird/plugins/conference_backend/schemas.py
+++ b/wazo_dird/plugins/conference_backend/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -18,7 +18,8 @@ from wazo_dird.schemas import (
 
 
 class ExtensionSchema(BaseSchema):
-    context = fields.String()
+    # "context" shadows marshmallow's Schema.context attribute (a dict)
+    context = fields.String()  # type: ignore[assignment]
     exten = fields.String()
 
 

--- a/wazo_dird/plugins/config/http.py
+++ b/wazo_dird/plugins/config/http.py
@@ -1,16 +1,15 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
 from typing import Any, cast
 
-from flask import request
 from jsonpatch import JsonPatch
 
 from wazo_dird.auth import required_acl, required_master_tenant
 from wazo_dird.config import Config as DirdConfig
-from wazo_dird.http import AuthResource
+from wazo_dird.http import AuthResource, get_json_body
 from wazo_dird.plugins.config_service.plugin import Service as ConfigService
 
 from .schemas import config_patch_schema
@@ -29,7 +28,7 @@ class Config(AuthResource):
     @required_master_tenant()
     @required_acl('dird.config.update')
     def patch(self) -> tuple[dict[str, Any], int]:
-        config_patch = config_patch_schema.load(request.get_json(force=True), many=True)
+        config_patch = config_patch_schema.load(get_json_body(many=True), many=True)
         config = self._config_service.get_config()
         patched_config = JsonPatch(config_patch).apply(cast('dict[str, Any]', config))
         self._config_service.update_config(cast('DirdConfig', patched_config))

--- a/wazo_dird/plugins/config/http.py
+++ b/wazo_dird/plugins/config/http.py
@@ -28,7 +28,7 @@ class Config(AuthResource):
     @required_master_tenant()
     @required_acl('dird.config.update')
     def patch(self) -> tuple[dict[str, Any], int]:
-        config_patch = config_patch_schema.load(get_json_body(many=True), many=True)
+        config_patch = config_patch_schema.load(get_json_body(), many=True)
         config = self._config_service.get_config()
         patched_config = JsonPatch(config_patch).apply(cast('dict[str, Any]', config))
         self._config_service.update_config(cast('DirdConfig', patched_config))

--- a/wazo_dird/plugins/displays/http.py
+++ b/wazo_dird/plugins/displays/http.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -10,7 +10,7 @@ from flask import request
 from xivo.tenant_flask_helpers import Tenant
 
 from wazo_dird.auth import required_acl
-from wazo_dird.http import AuthResource
+from wazo_dird.http import AuthResource, get_json_body
 from wazo_dird.plugin_helpers.tenant import get_tenant_uuids
 
 from .schemas import display_list_schema, display_schema, list_schema
@@ -41,7 +41,7 @@ class Displays(_BaseResource):
     @required_acl('dird.displays.create')
     def post(self) -> tuple[dict[str, Any], int]:
         tenant = Tenant.autodetect()
-        args = display_schema.load(request.get_json(force=True))
+        args = display_schema.load(get_json_body())
         body = self._display_service.create(tenant_uuid=tenant.uuid, **args)
         result: dict[str, Any] = display_schema.dump(body)
         return result, 201
@@ -64,7 +64,7 @@ class Display(_BaseResource):
     @required_acl('dird.displays.{display_uuid}.update')
     def put(self, display_uuid: str) -> tuple[str, int]:
         visible_tenants = get_tenant_uuids(recurse=True)
-        args = display_schema.load(request.get_json(force=True))
+        args = display_schema.load(get_json_body())
         self._display_service.edit(
             display_uuid, visible_tenants=visible_tenants, **args
         )

--- a/wazo_dird/plugins/office365_backend/http.py
+++ b/wazo_dird/plugins/office365_backend/http.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -75,7 +75,9 @@ class MicrosoftContactList(AuthResource):
         )
         microsoft_token = cast(
             'str',
-            get_microsoft_access_token(user_uuid, token_from_request, **source['auth']),
+            get_microsoft_access_token(
+                cast(str, user_uuid), cast(str, token_from_request), **source['auth']
+            ),
         )
 
         contacts, total = self.office365.get_contacts(

--- a/wazo_dird/plugins/personal/http.py
+++ b/wazo_dird/plugins/personal/http.py
@@ -18,7 +18,7 @@ from xivo.tenant_flask_helpers import Tenant
 
 from wazo_dird import auth
 from wazo_dird.auth import required_acl
-from wazo_dird.http import LegacyAuthResource
+from wazo_dird.http import LegacyAuthResource, get_json_body
 
 if TYPE_CHECKING:
     from wazo_dird.database.queries.base import ContactInfo
@@ -54,12 +54,12 @@ class PersonalAll(LegacyAuthResource):
     def post(self) -> tuple[dict[str, Any] | None, int]:
         user_uuid = _get_calling_user_uuid()
         tenant_uuid = Tenant.autodetect().uuid
-        contact = request.get_json(force=True)
+        contact = get_json_body()
         try:
-            contact = self.personal_service.create_contact(
+            created = self.personal_service.create_contact(
                 contact, user_uuid, tenant_uuid
             )
-            return contact, 201
+            return created, 201
         except self.personal_service.InvalidPersonalContact as e:
             error = {'reason': e.errors, 'timestamp': [time()], 'status_code': 400}
             return error, 400
@@ -170,7 +170,7 @@ class PersonalOne(LegacyAuthResource):
     def put(self, contact_id: str) -> tuple[dict[str, Any] | None, int]:
         user_uuid = _get_calling_user_uuid()
         tenant_uuid = Tenant.autodetect().uuid
-        new_contact = request.get_json(force=True)
+        new_contact = get_json_body()
         try:
             contact = self.personal_service.edit_contact(
                 contact_id, new_contact, user_uuid, tenant_uuid

--- a/wazo_dird/plugins/phonebook/http.py
+++ b/wazo_dird/plugins/phonebook/http.py
@@ -29,7 +29,7 @@ from wazo_dird.exception import (
     NoSuchTenant,
     PhonebookContactImportAPIError,
 )
-from wazo_dird.http import AuthResource
+from wazo_dird.http import AuthResource, get_json_body
 from wazo_dird.plugin_helpers.tenant import get_tenant_uuids
 from wazo_dird.plugins.phonebook_service.plugin import _PhonebookService
 
@@ -93,7 +93,7 @@ class PhonebookContactAll(_Resource):
             self.phonebook_service.create_contact(
                 visible_tenants,
                 PhonebookKey(uuid=str(phonebook_uuid)),
-                cast('dict[str, Any]', request.get_json(force=True)),
+                get_json_body(),
             ),
             201,
         )
@@ -144,7 +144,7 @@ class PhonebookAll(_Resource):
     @_default_error_route
     def post(self) -> tuple[PhonebookDict, int]:
         tenant = Tenant.autodetect()
-        body = cast('dict[str, Any]', request.get_json(force=True))
+        body = get_json_body()
         return (
             self.phonebook_service.create_phonebook(tenant.uuid, body),
             201,
@@ -256,7 +256,7 @@ class PhonebookContactOne(_Resource):
     @_default_error_route
     def put(self, phonebook_uuid: UUID, contact_uuid: UUID) -> tuple[ContactInfo, int]:
         visible_tenants = get_tenant_uuids(recurse=False)
-        body = cast('dict[str, Any]', request.get_json(force=True))
+        body = get_json_body()
         return (
             self.phonebook_service.edit_contact(
                 visible_tenants,
@@ -303,7 +303,7 @@ class PhonebookOne(_Resource):
     @_default_error_route
     def put(self, phonebook_uuid: UUID) -> tuple[PhonebookDict, int]:
         visible_tenants = get_tenant_uuids(recurse=False)
-        body = cast('dict[str, Any]', request.get_json(force=True))
+        body = get_json_body()
         return (
             self.phonebook_service.edit_phonebook(
                 visible_tenants,

--- a/wazo_dird/plugins/phonebook_deprecated/http.py
+++ b/wazo_dird/plugins/phonebook_deprecated/http.py
@@ -26,7 +26,7 @@ from wazo_dird.exception import (
     NoSuchPhonebook,
     NoSuchTenant,
 )
-from wazo_dird.http import LegacyAuthResource
+from wazo_dird.http import LegacyAuthResource, get_json_body
 
 if TYPE_CHECKING:
     from wazo_dird.plugins.phonebook_service.plugin import _PhonebookService
@@ -178,7 +178,7 @@ class DeprecatedPhonebookContactAll(_Resource):
             self.phonebook_service.create_contact(
                 [matching_tenant['uuid']],
                 PhonebookKey(id=phonebook_id),
-                request.get_json(force=True),
+                get_json_body(),
             ),
             201,
         )
@@ -238,7 +238,7 @@ class DeprecatedPhonebookAll(_Resource):
         matching_tenant = self._find_tenant(scoping_tenant, tenant)
         return (
             self.phonebook_service.create_phonebook(
-                matching_tenant['uuid'], request.get_json(force=True)
+                matching_tenant['uuid'], get_json_body()
             ),
             201,
         )
@@ -327,7 +327,7 @@ class DeprecatedPhonebookContactOne(_Resource):
                 [matching_tenant['uuid']],
                 PhonebookKey(id=phonebook_id),
                 contact_uuid,
-                request.get_json(force=True),
+                get_json_body(),
             ),
             200,
         )
@@ -376,7 +376,7 @@ class DeprecatedPhonebookOne(_Resource):
             self.phonebook_service.edit_phonebook(
                 [matching_tenant['uuid']],
                 PhonebookKey(id=phonebook_id),
-                request.get_json(force=True),
+                get_json_body(),
             ),
             200,
         )

--- a/wazo_dird/plugins/phonebook_deprecated/http.py
+++ b/wazo_dird/plugins/phonebook_deprecated/http.py
@@ -169,7 +169,6 @@ class DeprecatedPhonebookContactAll(_Resource):
     }
 
     @deprecated_endpoint
-    # required_acl comes from the untyped xivo.auth_verifier module
     @required_acl('dird.tenants.{tenant}.phonebooks.{phonebook_id}.contacts.create')
     @_default_error_route
     def post(self, tenant: str, phonebook_id: int) -> Response:
@@ -185,7 +184,6 @@ class DeprecatedPhonebookContactAll(_Resource):
         )
 
     @deprecated_endpoint
-    # required_acl comes from the untyped xivo.auth_verifier module
     @required_acl('dird.tenants.{tenant}.phonebooks.{phonebook_id}.contacts.read')
     @_default_error_route
     def get(self, tenant: str, phonebook_id: int) -> Response:
@@ -216,7 +214,6 @@ class DeprecatedPhonebookAll(_Resource):
     }
 
     @deprecated_endpoint
-    # required_acl comes from the untyped xivo.auth_verifier module
     @required_acl('dird.tenants.{tenant}.phonebooks.read')
     @_default_error_route
     def get(self, tenant: str) -> Response:
@@ -234,7 +231,6 @@ class DeprecatedPhonebookAll(_Resource):
         return {'items': phonebooks, 'total': count}
 
     @deprecated_endpoint
-    # required_acl comes from the untyped xivo.auth_verifier module
     @required_acl('dird.tenants.{tenant}.phonebooks.create')
     @_default_error_route
     def post(self, tenant: str) -> Response:
@@ -252,7 +248,6 @@ class DeprecatedPhonebookContactImport(_Resource):
     error_code_map = {NoSuchTenant: 404, NoSuchPhonebook: 404}
 
     @deprecated_endpoint
-    # required_acl comes from the untyped xivo.auth_verifier module
     @required_acl('dird.tenants.{tenant}.phonebooks.{phonebook_id}.contacts.create')
     @_default_error_route
     def post(self, tenant: str, phonebook_id: int) -> Response:
@@ -292,7 +287,6 @@ class DeprecatedPhonebookContactOne(_Resource):
     }
 
     @deprecated_endpoint
-    # required_acl comes from the untyped xivo.auth_verifier module
     @required_acl(
         'dird.tenants.{tenant}.phonebooks.{phonebook_id}.contacts.{contact_uuid}.read'
     )
@@ -308,7 +302,6 @@ class DeprecatedPhonebookContactOne(_Resource):
         )
 
     @deprecated_endpoint
-    # required_acl comes from the untyped xivo.auth_verifier module
     @required_acl(
         'dird.tenants.{tenant}.phonebooks.{phonebook_id}.contacts.{contact_uuid}.delete'
     )
@@ -322,7 +315,6 @@ class DeprecatedPhonebookContactOne(_Resource):
         return '', 204
 
     @deprecated_endpoint
-    # required_acl comes from the untyped xivo.auth_verifier module
     @required_acl(
         'dird.tenants.{tenant}.phonebooks.{phonebook_id}.contacts.{contact_uuid}.update'
     )
@@ -351,7 +343,6 @@ class DeprecatedPhonebookOne(_Resource):
     }
 
     @deprecated_endpoint
-    # required_acl comes from the untyped xivo.auth_verifier module
     @required_acl('dird.tenants.{tenant}.phonebooks.{phonebook_id}.delete')
     @_default_error_route
     def delete(self, tenant: str, phonebook_id: int) -> Response:
@@ -363,7 +354,6 @@ class DeprecatedPhonebookOne(_Resource):
         return '', 204
 
     @deprecated_endpoint
-    # required_acl comes from the untyped xivo.auth_verifier module
     @required_acl('dird.tenants.{tenant}.phonebooks.{phonebook_id}.read')
     @_default_error_route
     def get(self, tenant: str, phonebook_id: int) -> Response:
@@ -377,7 +367,6 @@ class DeprecatedPhonebookOne(_Resource):
         )
 
     @deprecated_endpoint
-    # required_acl comes from the untyped xivo.auth_verifier module
     @required_acl('dird.tenants.{tenant}.phonebooks.{phonebook_id}.update')
     @_default_error_route
     def put(self, tenant: str, phonebook_id: int) -> Response:

--- a/wazo_dird/plugins/profiles/http.py
+++ b/wazo_dird/plugins/profiles/http.py
@@ -10,7 +10,7 @@ from flask import request
 from xivo.tenant_flask_helpers import Tenant
 
 from wazo_dird.auth import required_acl
-from wazo_dird.http import AuthResource
+from wazo_dird.http import AuthResource, get_json_body
 from wazo_dird.plugin_helpers.tenant import get_tenant_uuids
 
 from .schemas import list_schema, profile_list_schema, profile_schema
@@ -41,7 +41,7 @@ class Profiles(_BaseResource):
     @required_acl('dird.profiles.create')
     def post(self) -> tuple[dict[str, Any], int]:
         tenant = Tenant.autodetect()
-        args = profile_schema.load(request.get_json(force=True))
+        args = profile_schema.load(get_json_body())
         body = self._profile_service.create(tenant_uuid=tenant.uuid, **args)
         result: dict[str, Any] = profile_schema.dump(body)
         return result, 201
@@ -64,7 +64,7 @@ class Profile(_BaseResource):
     @required_acl('dird.profiles.{profile_uuid}.update')
     def put(self, profile_uuid: str) -> tuple[str, int]:
         visible_tenants = get_tenant_uuids(recurse=True)
-        args = profile_schema.load(request.get_json(force=True))
+        args = profile_schema.load(get_json_body())
         self._profile_service.edit(
             profile_uuid, visible_tenants=visible_tenants, **args
         )

--- a/wazo_dird/plugins/profiles/schemas.py
+++ b/wazo_dird/plugins/profiles/schemas.py
@@ -35,7 +35,9 @@ class ServiceConfigSchema(BaseSchema):
 
 
 class ServiceDictSchema(fields.Nested):
-    def _serialize(
+    # marshmallow names _serialize's first arg "value" in Field but
+    # "nested_obj" in Nested; an override can't match both names.
+    def _serialize(  # type: ignore[override]
         self, nested_obj: Any, attr: str | None, obj: Any, **kwargs: Any
     ) -> dict[str, Any] | None:
         if nested_obj is None:
@@ -46,7 +48,7 @@ class ServiceDictSchema(fields.Nested):
             result[service_name] = ServiceConfigSchema().dump(service_config)
         return result
 
-    def _deserialize(
+    def _deserialize(  # type: ignore[override]
         self,
         nested_obj: Any,
         attr: str | None,

--- a/wazo_dird/tests/test_controller.py
+++ b/wazo_dird/tests/test_controller.py
@@ -49,6 +49,14 @@ class TestController(TestCase):
 
         self.rest_api.run.assert_called_once_with()
 
+    def test_init_without_uuid_when_service_discovery_disabled(self):
+        # XIVO_UUID may be unset (UUIDNotFound swallowed in main) when service
+        # discovery is disabled; Controller must still build.
+        config = self._create_config(**{'service_discovery': {'enabled': False}})
+        del config['uuid']
+
+        Controller(config)
+
     def test_run_loads_and_unloads_services(self):
         config = self._create_config(
             **{

--- a/wazo_dird/tests/test_controller.py
+++ b/wazo_dird/tests/test_controller.py
@@ -92,6 +92,9 @@ class TestController(TestCase):
 
     def _create_config(self, **kwargs):
         config = dict(kwargs)
+        config.setdefault('uuid', s.uuid)
+        config.setdefault('consul', {})
+        config.setdefault('service_discovery', {'enabled': False})
         config.setdefault('bus', {'enabled': False})
         config.setdefault('auth', {'host': 'localhost'})
         config.setdefault('confd', {'host': 'localhost'})


### PR DESCRIPTION
- **typing: drop typing proxies for xivo.auth_verifier**
- **pre-commit: sort additional dependencies**
- **typing: add get_json_body helper for request bodies**
- **typing: narrow optional/proxy values at xivo call sites**
- **typing: fix controller/main config and logger typing**
- **typing: silence unavoidable marshmallow field overrides**
- **mypy: ignore untyped third-party and wazo libs locally**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly typing and mypy config; the only user-visible API tweak is rejecting a JSON `null` request body with 400 where endpoints now use `get_json_body`.
> 
> **Overview**
> Tightens **mypy** and pre-commit typing: broader `pyproject.toml` overrides for untyped Wazo/third-party libs (Flask, SQLAlchemy, hamcrest, etc.), pins **marshmallow** in the mypy hook env, and reorders hook dependencies.
> 
> **Auth** drops local `cast` wrappers around `xivo.auth_verifier`’s `no_auth` / `required_acl` and uses those decorators directly; `required_master_tenant` is typed as a normal decorator and optional values are narrowed with `cast` at call sites.
> 
> Adds **`get_json_body()`** in `wazo_dird/http.py` and routes config, displays, profiles, phonebooks, personal, and related handlers through it instead of `request.get_json(force=True)`. Missing/invalid bodies still fail as before; a literal JSON **`null`** body now returns **400** (`invalid-data`) so mypy can treat the parsed body as non-optional.
> 
> Small typing fixes: `Controller` service-registration tuple and required `consul` / `service_discovery` / `bus` keys; `main` casts loaded config to `Config` after `set_xivo_uuid`; marshmallow `ServiceDictSchema` overrides marked with `# type: ignore[override]`; conference **`ExtensionSchema`** uses `context_` to avoid shadowing marshmallow’s `context`. Controller test covers startup when **`uuid`** is absent and service discovery is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27aa481a6f13b69aea678639cb1c7575207945aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->