### PR TITLE
ITEM-447-dynamic-thread-pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 26.08
+
+* New `rest_api.min_threads` option: threads kept ready at all times.
+  `max_threads` is now a ceiling the pool grows to under load, not a fixed
+  thread count.
+
 ## 26.07
 
 * `POST /0.1/profiles` and `PUT /0.1/profiles/<profile_uuid>`

--- a/etc/wazo-dird/config.yml
+++ b/etc/wazo-dird/config.yml
@@ -28,10 +28,16 @@ rest_api:
     # Allow JSON preflight requests
     allow_headers: [Content-Type, X-Auth-Token, Wazo-Tenant]
 
-  # Maximum of concurrent threads processing requests
+  # Minimum of concurrent threads processing requests. This many threads
+  # (and database connections) are kept ready at all times.
+  min_threads: 10
+
+  # Maximum of concurrent threads processing requests. The number of threads
+  # (and database connections) scales with demand between min_threads and
+  # max_threads.
   # See the performance documentation for more details
   # https://wazo-platform.org/uc-doc/system/performance/
-  max_threads: 10
+  max_threads: 100
 
 # Authentication server connection settings
 auth:

--- a/wazo_dird/config.py
+++ b/wazo_dird/config.py
@@ -58,6 +58,7 @@ class RestAPIConfig(TypedDict):
     certificate: None  # Deprecated
     private_key: None  # Deprecated
     cors: CORSConfig
+    min_threads: int
     max_threads: int
 
 
@@ -193,7 +194,8 @@ _DEFAULT_CONFIG: Config = {
             'enabled': True,
             'allow_headers': ['Content-Type', 'X-Auth-Token', 'Wazo-Tenant'],
         },
-        'max_threads': 10,
+        'min_threads': 10,
+        'max_threads': 100,
     },
     'reverse_service': {
         'executor_workers': None,  # None: inherit rest_api.max_threads

--- a/wazo_dird/controller.py
+++ b/wazo_dird/controller.py
@@ -25,6 +25,8 @@ from .source_manager import SourceManager
 
 logger = logging.getLogger(__name__)
 
+DB_POOL_SPARE_CONN = 10
+
 
 class Controller:
     config: Config
@@ -37,11 +39,14 @@ class Controller:
     def __init__(self, config: Config):
         self.config = config
         self._stopping_thread: threading.Thread | None = None
+        min_threads = config['rest_api']['min_threads']
+        max_threads = config['rest_api']['max_threads']
+        # Executors (lookup/reverse/favorites) don't need extra connections:
+        # HTTP threads hold none while waiting, and executors are capped at max_threads.
         init_db(
             config['db_uri'],
-            pool_size=config['rest_api']['min_threads'],
-            max_overflow=config['rest_api']['max_threads']
-            - config['rest_api']['min_threads'],
+            pool_size=min_threads,
+            max_overflow=max_threads - min_threads + DB_POOL_SPARE_CONN,
         )
         self.rest_api = CoreRestApi(self.config)
         self.bus = CoreBus(config.get('uuid'), **config['bus'])

--- a/wazo_dird/controller.py
+++ b/wazo_dird/controller.py
@@ -37,7 +37,12 @@ class Controller:
     def __init__(self, config: Config):
         self.config = config
         self._stopping_thread: threading.Thread | None = None
-        init_db(config['db_uri'], pool_size=config['rest_api']['max_threads'])
+        init_db(
+            config['db_uri'],
+            pool_size=config['rest_api']['min_threads'],
+            max_overflow=config['rest_api']['max_threads']
+            - config['rest_api']['min_threads'],
+        )
         self.rest_api = CoreRestApi(self.config)
         self.bus = CoreBus(config.get('uuid'), **config['bus'])
         auth.set_auth_config(self.config['auth'])

--- a/wazo_dird/database/helpers.py
+++ b/wazo_dird/database/helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import create_engine
@@ -8,7 +8,15 @@ from sqlalchemy.orm import scoped_session, sessionmaker
 Session = scoped_session(sessionmaker())
 
 
-def init_db(db_uri: str, echo: bool = False, pool_size: int = 16) -> Engine:
-    engine = create_engine(db_uri, echo=echo, pool_size=pool_size, pool_pre_ping=True)
+def init_db(
+    db_uri: str, echo: bool = False, pool_size: int = 16, max_overflow: int = 10
+) -> Engine:
+    engine = create_engine(
+        db_uri,
+        echo=echo,
+        pool_size=pool_size,
+        max_overflow=max_overflow,
+        pool_pre_ping=True,
+    )
     Session.configure(bind=engine)
     return engine

--- a/wazo_dird/http_server.py
+++ b/wazo_dird/http_server.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -50,7 +50,7 @@ class CoreRestApi:
         app.permanent_session_lifetime = timedelta(minutes=5)
         app.config.update(global_config)
         self.load_cors()
-        self.server: wsgi.WSGIServer | None = None
+        self.server: wsgi.DynamicWSGIServer | None = None
         self.app = app
         self.api = api
 
@@ -64,10 +64,11 @@ class CoreRestApi:
         bind_addr = (self.config['listen'], self.config['port'])
 
         wsgi_app = ReverseProxied(ProxyFix(wsgi.WSGIPathInfoDispatcher({'/': app})))
-        self.server = wsgi.WSGIServer(
+        self.server = wsgi.DynamicWSGIServer(
             bind_addr=bind_addr,
             wsgi_app=wsgi_app,
-            numthreads=self.config['max_threads'],
+            numthreads=self.config['min_threads'],
+            max=self.config['max_threads'],
         )
         if self.config['certificate'] and self.config['private_key']:
             logger.warning(

--- a/wazo_dird/tests/test_controller.py
+++ b/wazo_dird/tests/test_controller.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
@@ -39,6 +39,7 @@ class TestController(TestCase):
                     'listen': '127.0.0.1',
                     'port': '9489',
                     'certificate': 'my-certificate',
+                    'min_threads': 10,
                     'max_threads': 10,
                 },
                 'debug': s.debug,
@@ -116,6 +117,7 @@ class TestController(TestCase):
             {
                 'port': Mock(),
                 'certificate': 'my-certificate',
+                'min_threads': 10,
                 'max_threads': 10,
             },
         )


### PR DESCRIPTION
Note: lib-python must be merged first to make linter pass ...(todo: update zuul to use depends-on for typing)

Depends-on: https://github.com/wazo-platform/xivo-lib-python/pull/187

Why: max_threads was a fixed thread count spawned at startup, wasting
idle threads and DB connections on quiet systems. The pool now grows
and shrinks between the new min_threads setting and max_threads, which
becomes a real ceiling.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request concurrency and database pool sizing under load; mis-tuned min/max could affect capacity or connection usage, but no auth or data-model changes.
> 
> **Overview**
> Introduces **`rest_api.min_threads`** so wazo-dird keeps a baseline of worker threads (and DB connections) ready, while **`max_threads`** becomes an upper bound the pool grows toward under load instead of a fixed count spawned at startup.
> 
> The HTTP server switches from a fixed **`WSGIServer`** to **`DynamicWSGIServer`** (xivo-lib-python), starting with `min_threads` and capping at `max_threads`. **`init_db`** now uses `pool_size=min_threads` and a computed **`max_overflow`** so the SQLAlchemy pool can scale with demand (plus a small spare constant). Defaults and sample **`config.yml`** document the new option and raise the default **`max_threads`** to 100.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59d38b427ce4a240bad755ab3db3f848d07f5fb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->