### PR TITLE
misc(contribs): stress tests with locust

### DIFF
--- a/contribs/scripts/add_source_to_profile.sh
+++ b/contribs/scripts/add_source_to_profile.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Append an existing source to a service of an existing profile, in place.
+# Unlike create_phonebook_source.sh (which creates a brand-new profile), this
+# edits a profile that already exists — e.g. wiring a synthetic phonebook
+# source into the stock "default" profile's reverse lookup.
+#
+# Usage:
+#   SOURCE_UUID=... TOKEN=... TENANT=... bash contribs/scripts/add_source_to_profile.sh
+#
+# Required env vars:
+#   SOURCE_UUID      uuid of the source to add
+#   TOKEN            a valid X-Auth-Token
+#   TENANT           a valid Wazo-Tenant UUID
+#
+# Optional env vars:
+#   BASE_URL         (default: https://localhost:9489/0.1)
+#   PROFILE_NAME     profile to edit          (default: default)
+#   SERVICE          service to append to     (default: reverse)
+set -euo pipefail
+
+: "${SOURCE_UUID:?Set SOURCE_UUID env var to an existing source UUID}"
+: "${TOKEN:?Set TOKEN env var to a valid X-Auth-Token}"
+: "${TENANT:?Set TENANT env var to a valid Wazo-Tenant UUID}"
+
+BASE_URL="${BASE_URL:-https://localhost:9489/0.1}"
+PROFILE_NAME="${PROFILE_NAME:-default}"
+SERVICE="${SERVICE:-reverse}"
+
+CURL=(curl -sSk -H "X-Auth-Token: $TOKEN" -H "Wazo-Tenant: $TENANT")
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+# Fail on any HTTP error status, keeping the response body for diagnostics
+# (curl --fail-with-body alone would abort before a captured body is ever
+# printed).
+curl_or_die() {
+    local response rc=0
+    response=$("${CURL[@]}" --fail-with-body "$@") || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "$response" | jq . >&2 2>/dev/null || echo "$response" >&2
+        die "curl failed (exit $rc) — see response above"
+    fi
+    echo "$response"
+}
+
+# ── 1. Resolve profile UUID by name ───────────────────────────────────────────
+echo "=== Locating profile '$PROFILE_NAME' ==="
+PROFILES=$(curl_or_die "$BASE_URL/profiles")
+PROFILE_UUID=$(echo "$PROFILES" | jq -r --arg n "$PROFILE_NAME" \
+    '.items[] | select(.name == $n) | .uuid' | head -n1)
+[ -n "$PROFILE_UUID" ] && [ "$PROFILE_UUID" != "null" ] \
+    || die "no profile named '$PROFILE_NAME' in this tenant"
+echo "Profile UUID: $PROFILE_UUID"
+
+# ── 2. Append source to the target service (idempotent) ───────────────────────
+PROFILE=$(curl_or_die "$BASE_URL/profiles/$PROFILE_UUID")
+
+# Assumes the profile has a display (true for the stock "default" profile).
+BODY=$(echo "$PROFILE" | jq \
+    --arg src "$SOURCE_UUID" --arg svc "$SERVICE" '
+    .display = {uuid: .display.uuid}
+    | .services |= with_entries(.value.sources = ((.value.sources // []) | map({uuid: .uuid})))
+    | .services[$svc].sources = (
+        (.services[$svc].sources // []) as $s
+        | if ($s | any(.uuid == $src)) then $s else ($s + [{uuid: $src}]) end
+      )
+    | {name, display, services}')
+
+echo "=== Adding source $SOURCE_UUID to '$SERVICE' of '$PROFILE_NAME' ==="
+curl_or_die -H "Content-Type: application/json" \
+    -X PUT "$BASE_URL/profiles/$PROFILE_UUID" -d "$BODY" >/dev/null
+
+COUNT=$(curl_or_die "$BASE_URL/profiles/$PROFILE_UUID" \
+    | jq --arg svc "$SERVICE" '.services[$svc].sources | length')
+
+cat <<EOF
+
+============================================================
+  Done! '$PROFILE_NAME' now has $COUNT source(s) in '$SERVICE'.
+============================================================
+EOF

--- a/contribs/scripts/create_favorites.sh
+++ b/contribs/scripts/create_favorites.sh
@@ -28,13 +28,22 @@ CURL=(curl -sSk -H "X-Auth-Token: $TOKEN" -H "Wazo-Tenant: $TENANT")
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
+# Fail on any HTTP error status, keeping the response body for diagnostics
+# (curl --fail-with-body alone would abort before a captured body is ever
+# printed).
+curl_or_die() {
+    local response rc=0
+    response=$("${CURL[@]}" --fail-with-body "$@") || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "$response" | jq . >&2 2>/dev/null || echo "$response" >&2
+        die "curl failed (exit $rc) — see response above"
+    fi
+    echo "$response"
+}
+
 # ── 1. Look up one contact across all sources ─────────────────────────────────
 echo "=== Looking up '$SEARCH_TERM' in profile '$PROFILE' ==="
-RESPONSE=$("${CURL[@]}" "$BASE_URL/directories/lookup/$PROFILE?term=$SEARCH_TERM")
-if echo "$RESPONSE" | jq -e '.error_id' &>/dev/null; then
-    echo "$RESPONSE" | jq . >&2
-    die "lookup failed (see above)"
-fi
+RESPONSE=$(curl_or_die "$BASE_URL/directories/lookup/$PROFILE?term=$SEARCH_TERM")
 
 # Each result carries its source name and the source-specific contact id.
 mapfile -t PAIRS < <(
@@ -47,6 +56,9 @@ mapfile -t PAIRS < <(
 [ "${#PAIRS[@]}" -gt 0 ] || die "no results with a source_entry_id — is the phonebook populated and the profile wired?"
 
 # ── 2. Mark each (source, contact) as a favorite ──────────────────────────────
+# Uses a plain (non-failing) curl call: 409 (already a favorite) is tolerated,
+# and any other status only warns rather than aborting the whole batch — both
+# would be wrong under curl_or_die.
 echo "=== Marking ${#PAIRS[@]} favorites ==="
 CREATED=0
 for pair in "${PAIRS[@]}"; do

--- a/contribs/scripts/create_favorites.sh
+++ b/contribs/scripts/create_favorites.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Seed favorites for the load-test user so FavoritesUser exercises a real
+# fan-out. A single lookup for one synthetic contact returns one result per
+# source; each (source, contact) pair is then marked as a favorite, spreading
+# favorites across every source in the profile.
+#
+# Usage:
+#   TOKEN=... TENANT=... bash contribs/scripts/create_favorites.sh
+#
+# Required env vars:
+#   TOKEN            a valid X-Auth-Token (favorites are per-user/token)
+#   TENANT           a valid Wazo-Tenant UUID
+#
+# Optional env vars:
+#   BASE_URL         (default: https://localhost:9489/0.1)
+#   PROFILE          profile to look up and favorite in (default: default)
+#   SEARCH_TERM      term matching a synthetic contact   (default: Contact00001)
+set -euo pipefail
+
+: "${TOKEN:?Set TOKEN env var to a valid X-Auth-Token}"
+: "${TENANT:?Set TENANT env var to a valid Wazo-Tenant UUID}"
+
+BASE_URL="${BASE_URL:-https://localhost:9489/0.1}"
+PROFILE="${PROFILE:-default}"
+SEARCH_TERM="${SEARCH_TERM:-Contact00001}"
+
+CURL=(curl -sSk -H "X-Auth-Token: $TOKEN" -H "Wazo-Tenant: $TENANT")
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+# ── 1. Look up one contact across all sources ─────────────────────────────────
+echo "=== Looking up '$SEARCH_TERM' in profile '$PROFILE' ==="
+RESPONSE=$("${CURL[@]}" "$BASE_URL/directories/lookup/$PROFILE?term=$SEARCH_TERM")
+if echo "$RESPONSE" | jq -e '.error_id' &>/dev/null; then
+    echo "$RESPONSE" | jq . >&2
+    die "lookup failed (see above)"
+fi
+
+# Each result carries its source name and the source-specific contact id.
+mapfile -t PAIRS < <(
+    echo "$RESPONSE" |
+        jq -r '.results[] | select(.relations.source_entry_id != null)
+               | "\(.source)\t\(.relations.source_entry_id)"' |
+        sort -u
+)
+
+[ "${#PAIRS[@]}" -gt 0 ] || die "no results with a source_entry_id — is the phonebook populated and the profile wired?"
+
+# ── 2. Mark each (source, contact) as a favorite ──────────────────────────────
+echo "=== Marking ${#PAIRS[@]} favorites ==="
+CREATED=0
+for pair in "${PAIRS[@]}"; do
+    source="${pair%%$'\t'*}"
+    contact="${pair##*$'\t'}"
+    status=$("${CURL[@]}" -o /dev/null -w '%{http_code}' \
+        -X PUT "$BASE_URL/directories/favorites/$source/$contact")
+    case "$status" in
+        204) CREATED=$((CREATED + 1)); echo "  favorited: $source/$contact" ;;
+        409) echo "  already a favorite: $source/$contact" ;;
+        *) echo "  WARNING: PUT $source/$contact returned HTTP $status" >&2 ;;
+    esac
+done
+
+cat <<EOF
+
+============================================================
+  Done! $CREATED favorites created across ${#PAIRS[@]} sources.
+============================================================
+
+Run the favorites stress scenario:
+  WAZO_LOGIN=... WAZO_PASSWORD=... WAZO_TENANT=$TENANT WAZO_PROFILE=$PROFILE \\
+    tox -e load -- FavoritesUser --headless --users 50 --spawn-rate 5 --run-time 60s
+EOF

--- a/contribs/scripts/create_phonebook_source.sh
+++ b/contribs/scripts/create_phonebook_source.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Create N phonebook sources pointing at one phonebook, a display, and a
+# profile wiring them into the lookup, reverse and favorites services.
+# Reproduces the fan-out used by the load tests (one future per source).
+#
+# Usage:
+#   PHONEBOOK_UUID=... TOKEN=... TENANT=... bash contribs/scripts/create_phonebook_source.sh
+#
+# Required env vars:
+#   PHONEBOOK_UUID   uuid of the phonebook to point the sources at
+#   TOKEN            a valid X-Auth-Token
+#   TENANT           a valid Wazo-Tenant UUID
+#
+# Optional env vars:
+#   BASE_URL         (default: https://localhost:9489/0.1)
+#   PROFILE_NAME     (default: default)
+#   SOURCE_PREFIX    (default: synthetic-load-test-source)
+#   DISPLAY_NAME     (default: synthetic-load-test-display)
+#   NUM_SOURCES      number of sources to create (default: 8)
+set -euo pipefail
+
+: "${PHONEBOOK_UUID:?Set PHONEBOOK_UUID env var to an existing phonebook UUID}"
+: "${TOKEN:?Set TOKEN env var to a valid X-Auth-Token}"
+: "${TENANT:?Set TENANT env var to a valid Wazo-Tenant UUID}"
+
+BASE_URL="${BASE_URL:-https://localhost:9489/0.1}"
+PROFILE_NAME="${PROFILE_NAME:-default}"
+SOURCE_PREFIX="${SOURCE_PREFIX:-synthetic-load-test-source}"
+DISPLAY_NAME="${DISPLAY_NAME:-synthetic-load-test-display}"
+NUM_SOURCES="${NUM_SOURCES:-8}"
+
+CURL=(curl -sSk -H "X-Auth-Token: $TOKEN" -H "Wazo-Tenant: $TENANT")
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+check_error() {
+    local response="$1"
+    if echo "$response" | jq -e '.message // .error_id' &>/dev/null; then
+        echo "$response" | jq . >&2
+        die "API error (see above)"
+    fi
+}
+
+# ── 1. Create sources ─────────────────────────────────────────────────────────
+echo "=== Creating $NUM_SOURCES phonebook sources ==="
+SOURCE_UUIDS=()
+for i in $(seq 1 "$NUM_SOURCES"); do
+    RESPONSE=$("${CURL[@]}" -H "Content-Type: application/json" \
+        -X POST "$BASE_URL/backends/phonebook/sources" \
+        -d "{
+            \"name\": \"$SOURCE_PREFIX-$i\",
+            \"phonebook_uuid\": \"$PHONEBOOK_UUID\",
+            \"searched_columns\": [\"firstname\", \"lastname\", \"number\", \"mobile\", \"email\"],
+            \"first_matched_columns\": [\"number\", \"mobile\"],
+            \"format_columns\": {\"reverse\": \"{firstname} {lastname}\"}
+        }")
+    check_error "$RESPONSE"
+    UUID=$(echo "$RESPONSE" | jq -r '.uuid')
+    SOURCE_UUIDS+=("$UUID")
+    echo "  source $i/$NUM_SOURCES: $SOURCE_PREFIX-$i ($UUID)"
+done
+
+# JSON array of source identifiers, shared by all three services.
+SOURCES_JSON=$(printf '%s\n' "${SOURCE_UUIDS[@]}" | jq -R '{uuid: .}' | jq -s '.')
+
+# ── 2. Create display ─────────────────────────────────────────────────────────
+echo "=== Creating display '$DISPLAY_NAME' ==="
+RESPONSE=$("${CURL[@]}" -H "Content-Type: application/json" \
+    -X POST "$BASE_URL/displays" \
+    -d "{
+        \"name\": \"$DISPLAY_NAME\",
+        \"columns\": [
+            {\"title\": \"Firstname\", \"field\": \"firstname\"},
+            {\"title\": \"Lastname\", \"field\": \"lastname\"},
+            {\"title\": \"Number\", \"field\": \"number\"},
+            {\"title\": \"Mobile\", \"field\": \"mobile\"},
+            {\"title\": \"Email\", \"field\": \"email\"}
+        ]
+    }")
+check_error "$RESPONSE"
+DISPLAY_UUID=$(echo "$RESPONSE" | jq -r '.uuid')
+echo "Display UUID: $DISPLAY_UUID"
+
+# ── 3. Create profile ─────────────────────────────────────────────────────────
+echo "=== Creating profile '$PROFILE_NAME' ==="
+PROFILE_BODY=$(jq -n \
+    --arg name "$PROFILE_NAME" \
+    --arg display "$DISPLAY_UUID" \
+    --argjson sources "$SOURCES_JSON" \
+    '{
+        name: $name,
+        display: {uuid: $display},
+        services: {
+            lookup: {sources: $sources},
+            reverse: {sources: $sources},
+            favorites: {sources: $sources}
+        }
+    }')
+RESPONSE=$("${CURL[@]}" -H "Content-Type: application/json" \
+    -X POST "$BASE_URL/profiles" -d "$PROFILE_BODY")
+check_error "$RESPONSE"
+PROFILE_UUID=$(echo "$RESPONSE" | jq -r '.uuid')
+
+cat <<EOF
+
+============================================================
+  Done! Profile '$PROFILE_NAME' ($PROFILE_UUID) created with
+  $NUM_SOURCES sources wired into lookup, reverse and favorites.
+============================================================
+
+Next step — seed favorites for the load test user:
+  PROFILE=$PROFILE_NAME TOKEN=$TOKEN TENANT=$TENANT \\
+    bash contribs/scripts/create_favorites.sh
+EOF

--- a/contribs/scripts/create_phonebook_source.sh
+++ b/contribs/scripts/create_phonebook_source.sh
@@ -33,19 +33,24 @@ CURL=(curl -sSk -H "X-Auth-Token: $TOKEN" -H "Wazo-Tenant: $TENANT")
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
-check_error() {
-    local response="$1"
-    if echo "$response" | jq -e '.message // .error_id' &>/dev/null; then
-        echo "$response" | jq . >&2
-        die "API error (see above)"
+# Fail on any HTTP error status, keeping the response body for diagnostics
+# (curl --fail-with-body alone would abort before a captured body is ever
+# printed).
+curl_or_die() {
+    local response rc=0
+    response=$("${CURL[@]}" --fail-with-body "$@") || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "$response" | jq . >&2 2>/dev/null || echo "$response" >&2
+        die "curl failed (exit $rc) — see response above"
     fi
+    echo "$response"
 }
 
 # ── 1. Create sources ─────────────────────────────────────────────────────────
 echo "=== Creating $NUM_SOURCES phonebook sources ==="
 SOURCE_UUIDS=()
 for i in $(seq 1 "$NUM_SOURCES"); do
-    RESPONSE=$("${CURL[@]}" -H "Content-Type: application/json" \
+    RESPONSE=$(curl_or_die -H "Content-Type: application/json" \
         -X POST "$BASE_URL/backends/phonebook/sources" \
         -d "{
             \"name\": \"$SOURCE_PREFIX-$i\",
@@ -54,7 +59,6 @@ for i in $(seq 1 "$NUM_SOURCES"); do
             \"first_matched_columns\": [\"number\", \"mobile\"],
             \"format_columns\": {\"reverse\": \"{firstname} {lastname}\"}
         }")
-    check_error "$RESPONSE"
     UUID=$(echo "$RESPONSE" | jq -r '.uuid')
     SOURCE_UUIDS+=("$UUID")
     echo "  source $i/$NUM_SOURCES: $SOURCE_PREFIX-$i ($UUID)"
@@ -65,7 +69,7 @@ SOURCES_JSON=$(printf '%s\n' "${SOURCE_UUIDS[@]}" | jq -R '{uuid: .}' | jq -s '.
 
 # ── 2. Create display ─────────────────────────────────────────────────────────
 echo "=== Creating display '$DISPLAY_NAME' ==="
-RESPONSE=$("${CURL[@]}" -H "Content-Type: application/json" \
+RESPONSE=$(curl_or_die -H "Content-Type: application/json" \
     -X POST "$BASE_URL/displays" \
     -d "{
         \"name\": \"$DISPLAY_NAME\",
@@ -77,7 +81,6 @@ RESPONSE=$("${CURL[@]}" -H "Content-Type: application/json" \
             {\"title\": \"Email\", \"field\": \"email\"}
         ]
     }")
-check_error "$RESPONSE"
 DISPLAY_UUID=$(echo "$RESPONSE" | jq -r '.uuid')
 echo "Display UUID: $DISPLAY_UUID"
 
@@ -96,9 +99,8 @@ PROFILE_BODY=$(jq -n \
             favorites: {sources: $sources}
         }
     }')
-RESPONSE=$("${CURL[@]}" -H "Content-Type: application/json" \
+RESPONSE=$(curl_or_die -H "Content-Type: application/json" \
     -X POST "$BASE_URL/profiles" -d "$PROFILE_BODY")
-check_error "$RESPONSE"
 PROFILE_UUID=$(echo "$RESPONSE" | jq -r '.uuid')
 
 cat <<EOF

--- a/contribs/scripts/create_synthetic_phonebook.sh
+++ b/contribs/scripts/create_synthetic_phonebook.sh
@@ -28,28 +28,52 @@ CURL=(curl -sSk -H "X-Auth-Token: $TOKEN" -H "Wazo-Tenant: $TENANT")
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
-check_error() {
-    local response="$1"
-    if echo "$response" | jq -e '.message // .error_id' &>/dev/null; then
-        echo "$response" | jq . >&2
-        die "API error (see above)"
+# Fail on any HTTP error status, keeping the response body for diagnostics
+# (curl --fail-with-body alone would abort before a captured body is ever
+# printed).
+curl_or_die() {
+    local response rc=0
+    response=$("${CURL[@]}" --fail-with-body "$@") || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "$response" | jq . >&2 2>/dev/null || echo "$response" >&2
+        die "curl failed (exit $rc) — see response above"
     fi
+    echo "$response"
 }
 
-# ── 1. Create phonebook ───────────────────────────────────────────────────────
+# ── 1. Create phonebook (idempotent: reuse an existing one) ───────────────────
+# Uses a plain (non-failing) curl call: a 409 here means "already exists" and
+# must be tolerated rather than aborting like curl_or_die would.
 echo "=== Creating phonebook '$PHONEBOOK_NAME' ==="
 RESPONSE=$("${CURL[@]}" -H "Content-Type: application/json" \
     -X POST "$BASE_URL/phonebooks" \
     -d "{\"name\": \"$PHONEBOOK_NAME\", \"description\": \"Synthetic $COUNT-contact phonebook for load testing\"}")
-check_error "$RESPONSE"
-PB_UUID=$(echo "$RESPONSE" | jq -r '.uuid')
+STATUS=$(echo "$RESPONSE" | jq -r '.status_code // empty')
+if [ "$STATUS" = "409" ]; then
+    echo "  phonebook '$PHONEBOOK_NAME' already exists — reusing it"
+    PB_UUID=$(curl_or_die "$BASE_URL/phonebooks" \
+        | jq -r --arg n "$PHONEBOOK_NAME" '.items[] | select(.name == $n) | .uuid' | head -n1)
+elif [ -n "$STATUS" ] && [ "$STATUS" -ge 400 ] 2>/dev/null; then
+    echo "$RESPONSE" | jq . >&2
+    die "API error (status $STATUS) — see above"
+else
+    PB_UUID=$(echo "$RESPONSE" | jq -r '.uuid')
+fi
+[ -n "$PB_UUID" ] && [ "$PB_UUID" != "null" ] || die "could not determine phonebook UUID"
 echo "Phonebook UUID: $PB_UUID"
 
 # ── 2. Import contacts in batches ─────────────────────────────────────────────
-BATCHES=$(( (COUNT + BATCH_SIZE - 1) / BATCH_SIZE ))
-TOTAL_CREATED=0
+EXISTING=$(curl_or_die "$BASE_URL/phonebooks/$PB_UUID/contacts?limit=1" | jq -r '.total // 0')
+if [ "$EXISTING" -ge "$COUNT" ]; then
+    echo "=== Phonebook already has $EXISTING contacts (>= $COUNT) — skipping import ==="
+    TOTAL_CREATED="$EXISTING"
+    BATCHES=0
+fi
 
-echo "=== Importing $COUNT contacts in $BATCHES batches of $BATCH_SIZE ==="
+BATCHES=${BATCHES:-$(( (COUNT + BATCH_SIZE - 1) / BATCH_SIZE ))}
+TOTAL_CREATED=${TOTAL_CREATED:-0}
+
+[ "$BATCHES" -gt 0 ] && echo "=== Importing $COUNT contacts in $BATCHES batches of $BATCH_SIZE ==="
 
 for batch in $(seq 1 "$BATCHES"); do
     START=$(( (batch - 1) * BATCH_SIZE ))
@@ -65,11 +89,10 @@ for i in range(start, end + 1):
 PY
 )
 
-    RESPONSE=$(echo "$CSV" | "${CURL[@]}" \
+    RESPONSE=$(echo "$CSV" | curl_or_die \
         -H "Content-Type: text/csv; charset=utf-8" \
         -X POST "$BASE_URL/phonebooks/$PB_UUID/contacts/import" \
         --data-binary @-)
-    check_error "$RESPONSE"
 
     CREATED=$(echo "$RESPONSE" | jq '.created | length')
     FAILED_COUNT=$(echo "$RESPONSE" | jq '.failed | length')

--- a/contribs/scripts/create_synthetic_phonebook.sh
+++ b/contribs/scripts/create_synthetic_phonebook.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Create a synthetic phonebook with N contacts for load/performance testing.
+# Matches the schema used by integration_tests/suite/test_graphql_load.py.
+#
+# Usage:
+#   TOKEN=... TENANT=... bash contribs/scripts/create_synthetic_phonebook.sh
+#
+# Optional env vars:
+#   BASE_URL         (default: https://localhost:9489/0.1)
+#   PHONEBOOK_NAME   (default: synthetic-load-test)
+#   COUNT            number of contacts to create (default: 25000)
+#   BATCH_SIZE       contacts per import request  (default: 5000)
+#   NUMBER_BASE      base phone number            (default: 1000000000)
+#   MOBILE_BASE      base mobile number           (default: 33600000000)
+set -euo pipefail
+
+: "${TOKEN:?Set TOKEN env var to a valid X-Auth-Token}"
+: "${TENANT:?Set TENANT env var to a valid Wazo-Tenant UUID}"
+
+BASE_URL="${BASE_URL:-https://localhost:9489/0.1}"
+PHONEBOOK_NAME="${PHONEBOOK_NAME:-synthetic-load-test}"
+COUNT="${COUNT:-25000}"
+BATCH_SIZE="${BATCH_SIZE:-5000}"
+NUMBER_BASE="${NUMBER_BASE:-1000000000}"
+MOBILE_BASE="${MOBILE_BASE:-33600000000}"
+
+CURL=(curl -sSk -H "X-Auth-Token: $TOKEN" -H "Wazo-Tenant: $TENANT")
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+check_error() {
+    local response="$1"
+    if echo "$response" | jq -e '.message // .error_id' &>/dev/null; then
+        echo "$response" | jq . >&2
+        die "API error (see above)"
+    fi
+}
+
+# ── 1. Create phonebook ───────────────────────────────────────────────────────
+echo "=== Creating phonebook '$PHONEBOOK_NAME' ==="
+RESPONSE=$("${CURL[@]}" -H "Content-Type: application/json" \
+    -X POST "$BASE_URL/phonebooks" \
+    -d "{\"name\": \"$PHONEBOOK_NAME\", \"description\": \"Synthetic $COUNT-contact phonebook for load testing\"}")
+check_error "$RESPONSE"
+PB_UUID=$(echo "$RESPONSE" | jq -r '.uuid')
+echo "Phonebook UUID: $PB_UUID"
+
+# ── 2. Import contacts in batches ─────────────────────────────────────────────
+BATCHES=$(( (COUNT + BATCH_SIZE - 1) / BATCH_SIZE ))
+TOTAL_CREATED=0
+
+echo "=== Importing $COUNT contacts in $BATCHES batches of $BATCH_SIZE ==="
+
+for batch in $(seq 1 "$BATCHES"); do
+    START=$(( (batch - 1) * BATCH_SIZE ))
+    END=$(( batch * BATCH_SIZE - 1 ))
+    [ "$END" -ge "$COUNT" ] && END=$(( COUNT - 1 ))
+
+    CSV=$(python3 - "$START" "$END" "$NUMBER_BASE" "$MOBILE_BASE" <<'PY'
+import sys
+start, end, nb, mb = int(sys.argv[1]), int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4])
+print("firstname,lastname,number,mobile,email")
+for i in range(start, end + 1):
+    print(f"Contact{i:05d},McContact{i:05d},{nb+i},{mb+i},contact{i:05d}@example.com")
+PY
+)
+
+    RESPONSE=$(echo "$CSV" | "${CURL[@]}" \
+        -H "Content-Type: text/csv; charset=utf-8" \
+        -X POST "$BASE_URL/phonebooks/$PB_UUID/contacts/import" \
+        --data-binary @-)
+    check_error "$RESPONSE"
+
+    CREATED=$(echo "$RESPONSE" | jq '.created | length')
+    FAILED_COUNT=$(echo "$RESPONSE" | jq '.failed | length')
+    TOTAL_CREATED=$(( TOTAL_CREATED + CREATED ))
+
+    if [ "$FAILED_COUNT" -gt 0 ]; then
+        echo "  WARNING: $FAILED_COUNT contacts failed in batch $batch" >&2
+        echo "$RESPONSE" | jq '.failed[:3]' >&2
+    fi
+
+    echo "  batch $batch/$BATCHES: $CREATED created, $FAILED_COUNT failed ($TOTAL_CREATED/$COUNT total)"
+done
+
+# ── 3. Summary ────────────────────────────────────────────────────────────────
+cat <<EOF
+
+============================================================
+  Done! $TOTAL_CREATED contacts created.
+  Phonebook:  $PHONEBOOK_NAME
+  UUID:       $PB_UUID
+============================================================
+
+Next steps — create a source pointing at this phonebook:
+  PHONEBOOK_UUID=$PB_UUID TOKEN=$TOKEN TENANT=$TENANT \\
+    bash contribs/scripts/create_phonebook_source.sh
+EOF

--- a/contribs/stress_tests/.env.sample
+++ b/contribs/stress_tests/.env.sample
@@ -1,0 +1,27 @@
+# See locustfile.py header for full descriptions. Target host is passed via
+# locust's -H flag, not an env var.
+
+# wazo-auth username
+WAZO_LOGIN=root
+# wazo-auth password
+WAZO_PASSWORD=secret
+# tenant UUID sent as Wazo-Tenant header
+WAZO_TENANT=
+# auth base URL including scheme and port (default: <host-from--H-flag>/api/auth)
+WAZO_AUTH_HOST=
+# profile name for the queries
+WAZO_PROFILE=default
+# lowest phone number in the phonebook
+NUMBER_BASE=1000000000
+# lowest mobile number in the phonebook
+MOBILE_BASE=33600000000
+# number of contacts in the phonebook
+PHONEBOOK_COUNT=25000
+# fail if p95 response time exceeds this value in ms
+P95_THRESHOLD_MS=4000
+# fail if error rate exceeds this %
+FAIL_RATIO_PCT=5
+# per-request hard ceiling in seconds (fail fast instead of hanging)
+REQUEST_TIMEOUT=30
+# token lifetime when --run-time is unset
+TOKEN_EXPIRATION=600

--- a/contribs/stress_tests/locustfile.py
+++ b/contribs/stress_tests/locustfile.py
@@ -1,0 +1,253 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Stress-test for wazo-dird directory services against a real Wazo stack.
+# Three scenarios, each exercising one service's ThreadPoolExecutor fan-out
+# (one future per profile source):
+#
+#   GraphQLReverseLookupUser  GraphQL reverse lookup (reverse_service pool)
+#   LookupUser                REST lookup by term     (lookup_service pool)
+#   FavoritesUser             REST favorites listing  (favorites_service pool)
+#
+# All scenarios assume a synthetic phonebook and a profile with several sources
+# already exist on the target stack (see contribs/create_synthetic_phonebook.sh
+# and contribs/create_phonebook_source.sh). FavoritesUser additionally requires
+# favorites to be seeded for the test user (see contribs/create_favorites.sh).
+#
+# Requirements:  pip install locust
+#
+# Usage (run ONE scenario at a time to isolate a single service's pool):
+#   export WAZO_LOGIN=root WAZO_PASSWORD=secret WAZO_TENANT=<tenant-uuid>
+#   locust -f locustfile.py GraphQLReverseLookupUser -H https://<stack-host> \
+#     --headless --users 50 --spawn-rate 5 --run-time 60s
+#   locust -f locustfile.py LookupUser    -H https://<stack-host> --headless ...
+#   locust -f locustfile.py FavoritesUser -H https://<stack-host> --headless ...
+#
+# Required env vars:
+#   WAZO_LOGIN          wazo-auth username
+#   WAZO_PASSWORD       wazo-auth password
+#   WAZO_TENANT         tenant UUID sent as Wazo-Tenant header
+#
+# Optional env vars:
+#   WAZO_AUTH_HOST      auth base URL (default: WAZO_HOST/api/auth)
+#   WAZO_PROFILE        profile name for the queries (default: default)
+#   NUMBER_BASE         lowest phone number in the phonebook  (default: 1000000000)
+#   MOBILE_BASE         lowest mobile number in the phonebook (default: 33600000000)
+#   PHONEBOOK_COUNT     number of contacts in the phonebook   (default: 25000)
+#   P95_THRESHOLD_MS    fail if p95 exceeds this value in ms  (default: 4000)
+#   FAIL_RATIO_PCT      fail if error rate exceeds this %     (default: 5)
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import random
+import ssl
+import urllib.request
+from typing import TYPE_CHECKING
+
+from locust import FastHttpUser, between, events, task
+from locust.env import Environment
+
+if TYPE_CHECKING:
+    from locust.contrib.fasthttp import ResponseContextManager
+
+_LOGIN = os.environ['WAZO_LOGIN']
+_PASSWORD = os.environ['WAZO_PASSWORD']
+_TENANT = os.getenv('WAZO_TENANT', '')
+_PROFILE = os.getenv('WAZO_PROFILE', 'default')
+_NUMBER_BASE = int(os.getenv('NUMBER_BASE', '1000000000'))
+_MOBILE_BASE = int(os.getenv('MOBILE_BASE', '33600000000'))
+_PHONEBOOK_COUNT = int(os.getenv('PHONEBOOK_COUNT', '25000'))
+_P95_THRESHOLD_MS = int(os.getenv('P95_THRESHOLD_MS', '4000'))
+_FAIL_RATIO_PCT = float(os.getenv('FAIL_RATIO_PCT', '5'))
+
+_SSL_CTX = ssl.create_default_context()
+_SSL_CTX.check_hostname = False
+_SSL_CTX.verify_mode = ssl.CERT_NONE
+
+
+def _create_token(host: str) -> str:
+    auth_host = os.getenv('WAZO_AUTH_HOST', f'{host}/api/auth')
+    credentials = base64.b64encode(f'{_LOGIN}:{_PASSWORD}'.encode()).decode()
+    req = urllib.request.Request(
+        f'{auth_host}/0.1/token',
+        data=json.dumps({'expiration': 600}).encode(),
+        headers={
+            'Content-Type': 'application/json',
+            'Authorization': f'Basic {credentials}',
+        },
+        method='POST',
+    )
+    with urllib.request.urlopen(req, context=_SSL_CTX) as resp:
+        data = json.loads(resp.read())
+    return data['data']['token']
+
+
+def _delete_token(host: str, token: str) -> None:
+    auth_host = os.getenv('WAZO_AUTH_HOST', f'{host}/api/auth')
+    req = urllib.request.Request(f'{auth_host}/0.1/token/{token}', method='DELETE')
+    try:
+        urllib.request.urlopen(req, context=_SSL_CTX).close()
+    except urllib.error.URLError as e:
+        logging.warning('failed to delete token: %s', e)
+
+
+class GraphQLReverseLookupUser(FastHttpUser):
+    """
+    Simulates one application instance resolving call-history entries via
+    GraphQL reverse lookup.  Each task picks 0-35 extensions drawn from the
+    synthetic phonebook. All virtual users share a single token created at
+    test_start, so authentication latency is excluded from the stats.
+    """
+
+    wait_time = between(0.5, 3.0)
+
+    @task
+    def reverse_lookup(self) -> None:
+        n_extens = random.randint(0, 35)
+        indices = random.sample(range(_PHONEBOOK_COUNT), n_extens) if n_extens else []
+        # Mix number and mobile fields to exercise both first_matched_columns
+        extens = [
+            str(_NUMBER_BASE + i) if random.random() < 0.5 else str(_MOBILE_BASE + i)
+            for i in indices
+        ]
+
+        query = (
+            '{ me { contacts(profile: "'
+            + _PROFILE
+            + '", extens: '
+            + json.dumps(extens)
+            + ') { edges { node { firstname lastname wazoReverse } } } } }'
+        )
+
+        headers = {'X-Auth-Token': _TOKEN, 'Content-Type': 'application/json'}
+        if _TENANT:
+            headers['Wazo-Tenant'] = _TENANT
+
+        with self.client.post(
+            '/api/dird/0.1/graphql',
+            name='graphql_reverse_lookup',
+            headers=headers,
+            json={'query': query},
+            catch_response=True,
+            timeout=_P95_THRESHOLD_MS / 1000,
+        ) as response:
+            if not response.status_code:
+                response.failure('timeout or connection error')
+            else:
+                response.raise_for_status()
+                body = response.json()
+                if 'errors' in body:
+                    response.failure(str(body['errors'])[:200])
+                else:
+                    response.success()
+
+
+def _query_headers() -> dict[str, str]:
+    headers = {'X-Auth-Token': _TOKEN}
+    if _TENANT:
+        headers['Wazo-Tenant'] = _TENANT
+    return headers
+
+
+def _check_rest_response(response: ResponseContextManager) -> None:
+    if not response.status_code:
+        response.failure('timeout or connection error')
+    else:
+        response.raise_for_status()
+        response.success()
+
+
+class LookupUser(FastHttpUser):
+    """
+    Simulates contact search: each task searches the firstname of a random
+    synthetic contact, fanning out one future per profile source in the
+    lookup_service ThreadPoolExecutor.
+    """
+
+    wait_time = between(0.5, 3.0)
+
+    @task
+    def lookup(self) -> None:
+        term = f'Contact{random.randrange(_PHONEBOOK_COUNT):05d}'
+        with self.client.get(
+            f'/api/dird/0.1/directories/lookup/{_PROFILE}',
+            name='lookup',
+            headers=_query_headers(),
+            params={'term': term},
+            catch_response=True,
+            timeout=_P95_THRESHOLD_MS / 1000,
+        ) as response:
+            _check_rest_response(response)
+
+
+class FavoritesUser(FastHttpUser):
+    """
+    Simulates favorites listing: each task lists the test user's favorites,
+    fanning out one future per source holding a favorite in the
+    favorites_service ThreadPoolExecutor.
+
+    Favorites must be seeded beforehand (see contribs/create_favorites.sh);
+    with no favorites the listing still succeeds but exercises no fan-out.
+    """
+
+    wait_time = between(0.5, 3.0)
+
+    @task
+    def favorites(self) -> None:
+        with self.client.get(
+            f'/api/dird/0.1/directories/favorites/{_PROFILE}',
+            name='favorites',
+            headers=_query_headers(),
+            catch_response=True,
+            timeout=_P95_THRESHOLD_MS / 1000,
+        ) as response:
+            _check_rest_response(response)
+
+
+_TOKEN = ''
+
+
+@events.test_start.add_listener
+def on_test_start(environment: Environment, **kw: dict) -> None:
+    global _TOKEN
+    _TOKEN = _create_token(environment.host)
+    logging.info(
+        'target: %s  profile: %s  phonebook: %d contacts',
+        environment.host,
+        _PROFILE,
+        _PHONEBOOK_COUNT,
+    )
+
+
+@events.test_stop.add_listener
+def on_test_stop(environment: Environment, **kw: dict) -> None:
+    if _TOKEN:
+        _delete_token(environment.host, _TOKEN)
+
+
+@events.quitting.add_listener
+def on_quit(environment: Environment, **kw: dict) -> None:
+    stats = environment.stats.total
+    p95 = stats.get_response_time_percentile(0.95)
+    fail_pct = stats.fail_ratio * 100
+    logging.info(
+        'results: rps=%.1f  p50=%.0fms  p95=%.0fms  p99=%.0fms  failures=%.1f%%',
+        stats.current_rps,
+        stats.get_response_time_percentile(0.50),
+        p95,
+        stats.get_response_time_percentile(0.99),
+        fail_pct,
+    )
+    if fail_pct > _FAIL_RATIO_PCT:
+        logging.error('FAIL: failure rate %.1f%% > %.1f%%', fail_pct, _FAIL_RATIO_PCT)
+        environment.process_exit_code = 1
+    elif p95 > _P95_THRESHOLD_MS:
+        logging.error('FAIL: p95 %.0fms > %dms', p95, _P95_THRESHOLD_MS)
+        environment.process_exit_code = 1
+    else:
+        logging.info('PASS')
+        environment.process_exit_code = 0

--- a/contribs/stress_tests/locustfile.py
+++ b/contribs/stress_tests/locustfile.py
@@ -36,6 +36,7 @@
 #   PHONEBOOK_COUNT     number of contacts in the phonebook   (default: 25000)
 #   P95_THRESHOLD_MS    fail if p95 exceeds this value in ms  (default: 4000)
 #   FAIL_RATIO_PCT      fail if error rate exceeds this %     (default: 5)
+#   TOKEN_EXPIRATION    token lifetime when --run-time is unset (default: 600)
 
 from __future__ import annotations
 
@@ -63,18 +64,21 @@ _MOBILE_BASE = int(os.getenv('MOBILE_BASE', '33600000000'))
 _PHONEBOOK_COUNT = int(os.getenv('PHONEBOOK_COUNT', '25000'))
 _P95_THRESHOLD_MS = int(os.getenv('P95_THRESHOLD_MS', '4000'))
 _FAIL_RATIO_PCT = float(os.getenv('FAIL_RATIO_PCT', '5'))
+_TOKEN_EXPIRATION = int(os.getenv('TOKEN_EXPIRATION', '600'))
+# Extra token lifetime beyond --run-time so the token outlives ramp-up/teardown.
+_TOKEN_MARGIN = 60
 
 _SSL_CTX = ssl.create_default_context()
 _SSL_CTX.check_hostname = False
 _SSL_CTX.verify_mode = ssl.CERT_NONE
 
 
-def _create_token(host: str) -> str:
+def _create_token(host: str, expiration: int) -> str:
     auth_host = os.getenv('WAZO_AUTH_HOST', f'{host}/api/auth')
     credentials = base64.b64encode(f'{_LOGIN}:{_PASSWORD}'.encode()).decode()
     req = urllib.request.Request(
         f'{auth_host}/0.1/token',
-        data=json.dumps({'expiration': 600}).encode(),
+        data=json.dumps({'expiration': expiration}).encode(),
         headers={
             'Content-Type': 'application/json',
             'Authorization': f'Basic {credentials}',
@@ -214,7 +218,11 @@ _TOKEN = ''
 @events.test_start.add_listener
 def on_test_start(environment: Environment, **kw: dict) -> None:
     global _TOKEN
-    _TOKEN = _create_token(environment.host)
+    run_time = (
+        environment.parsed_options.run_time if environment.parsed_options else None
+    )
+    expiration = run_time + _TOKEN_MARGIN if run_time else _TOKEN_EXPIRATION
+    _TOKEN = _create_token(environment.host, expiration)
     logging.info(
         'target: %s  profile: %s  phonebook: %d contacts',
         environment.host,

--- a/contribs/stress_tests/locustfile.py
+++ b/contribs/stress_tests/locustfile.py
@@ -10,9 +10,10 @@
 #   FavoritesUser             REST favorites listing  (favorites_service pool)
 #
 # All scenarios assume a synthetic phonebook and a profile with several sources
-# already exist on the target stack (see contribs/create_synthetic_phonebook.sh
-# and contribs/create_phonebook_source.sh). FavoritesUser additionally requires
-# favorites to be seeded for the test user (see contribs/create_favorites.sh).
+# already exist on the target stack (see contribs/scripts/create_synthetic_phonebook.sh
+# and contribs/scripts/create_phonebook_source.sh). FavoritesUser additionally
+# requires favorites to be seeded for the test user (see
+# contribs/scripts/create_favorites.sh).
 #
 # Requirements:  pip install locust
 #
@@ -204,7 +205,7 @@ class FavoritesUser(_DirdUser):
     fanning out one future per source holding a favorite in the
     favorites_service ThreadPoolExecutor.
 
-    Favorites must be seeded beforehand (see contribs/create_favorites.sh);
+    Favorites must be seeded beforehand (see contribs/scripts/create_favorites.sh);
     with no favorites the listing still succeeds but exercises no fan-out.
     """
 

--- a/contribs/stress_tests/locustfile.py
+++ b/contribs/stress_tests/locustfile.py
@@ -36,6 +36,7 @@
 #   PHONEBOOK_COUNT     number of contacts in the phonebook   (default: 25000)
 #   P95_THRESHOLD_MS    fail if p95 exceeds this value in ms  (default: 4000)
 #   FAIL_RATIO_PCT      fail if error rate exceeds this %     (default: 5)
+#   REQUEST_TIMEOUT     per-request hard ceiling in seconds   (default: 30)
 #   TOKEN_EXPIRATION    token lifetime when --run-time is unset (default: 600)
 
 from __future__ import annotations
@@ -64,6 +65,10 @@ _MOBILE_BASE = int(os.getenv('MOBILE_BASE', '33600000000'))
 _PHONEBOOK_COUNT = int(os.getenv('PHONEBOOK_COUNT', '25000'))
 _P95_THRESHOLD_MS = int(os.getenv('P95_THRESHOLD_MS', '4000'))
 _FAIL_RATIO_PCT = float(os.getenv('FAIL_RATIO_PCT', '5'))
+# Hard per-request ceiling so a stalled dird fails fast instead of hanging for
+# FastHttpUser's 60s default; kept above P95_THRESHOLD_MS so merely-slow requests
+# still complete and count toward p95.
+_REQUEST_TIMEOUT = float(os.getenv('REQUEST_TIMEOUT', '30'))
 _TOKEN_EXPIRATION = int(os.getenv('TOKEN_EXPIRATION', '600'))
 # Extra token lifetime beyond --run-time so the token outlives ramp-up/teardown.
 _TOKEN_MARGIN = 60
@@ -99,15 +104,22 @@ def _delete_token(host: str, token: str) -> None:
         logging.warning('failed to delete token: %s', e)
 
 
-class GraphQLReverseLookupUser(FastHttpUser):
+class _DirdUser(FastHttpUser):
+    abstract = True
+    wait_time = between(0.5, 3.0)
+    # network_timeout/connection_timeout are the only honoured per-request
+    # ceilings; FastHttpSession.request has no `timeout` kwarg.
+    network_timeout = _REQUEST_TIMEOUT
+    connection_timeout = _REQUEST_TIMEOUT
+
+
+class GraphQLReverseLookupUser(_DirdUser):
     """
     Simulates one application instance resolving call-history entries via
     GraphQL reverse lookup.  Each task picks 0-35 extensions drawn from the
     synthetic phonebook. All virtual users share a single token created at
     test_start, so authentication latency is excluded from the stats.
     """
-
-    wait_time = between(0.5, 3.0)
 
     @task
     def reverse_lookup(self) -> None:
@@ -137,7 +149,6 @@ class GraphQLReverseLookupUser(FastHttpUser):
             headers=headers,
             json={'query': query},
             catch_response=True,
-            timeout=_P95_THRESHOLD_MS / 1000,
         ) as response:
             if not response.status_code:
                 response.failure('timeout or connection error')
@@ -167,14 +178,12 @@ def _check_rest_response(response: ResponseContextManager) -> None:
         response.success()
 
 
-class LookupUser(FastHttpUser):
+class LookupUser(_DirdUser):
     """
     Simulates contact search: each task searches the firstname of a random
     synthetic contact, fanning out one future per profile source in the
     lookup_service ThreadPoolExecutor.
     """
-
-    wait_time = between(0.5, 3.0)
 
     @task
     def lookup(self) -> None:
@@ -185,12 +194,11 @@ class LookupUser(FastHttpUser):
             headers=_query_headers(),
             params={'term': term},
             catch_response=True,
-            timeout=_P95_THRESHOLD_MS / 1000,
         ) as response:
             _check_rest_response(response)
 
 
-class FavoritesUser(FastHttpUser):
+class FavoritesUser(_DirdUser):
     """
     Simulates favorites listing: each task lists the test user's favorites,
     fanning out one future per source holding a favorite in the
@@ -200,8 +208,6 @@ class FavoritesUser(FastHttpUser):
     with no favorites the listing still succeeds but exercises no fan-out.
     """
 
-    wait_time = between(0.5, 3.0)
-
     @task
     def favorites(self) -> None:
         with self.client.get(
@@ -209,7 +215,6 @@ class FavoritesUser(FastHttpUser):
             name='favorites',
             headers=_query_headers(),
             catch_response=True,
-            timeout=_P95_THRESHOLD_MS / 1000,
         ) as response:
             _check_rest_response(response)
 

--- a/contribs/stress_tests/locustfile.py
+++ b/contribs/stress_tests/locustfile.py
@@ -141,8 +141,9 @@ class GraphQLReverseLookupUser(FastHttpUser):
         ) as response:
             if not response.status_code:
                 response.failure('timeout or connection error')
+            elif response.status_code >= 400:
+                response.failure(f'HTTP {response.status_code}')
             else:
-                response.raise_for_status()
                 body = response.json()
                 if 'errors' in body:
                     response.failure(str(body['errors'])[:200])
@@ -160,8 +161,9 @@ def _query_headers() -> dict[str, str]:
 def _check_rest_response(response: ResponseContextManager) -> None:
     if not response.status_code:
         response.failure('timeout or connection error')
+    elif response.status_code >= 400:
+        response.failure(f'HTTP {response.status_code}')
     else:
-        response.raise_for_status()
         response.success()
 
 

--- a/contribs/stress_tests/locustfile.py
+++ b/contribs/stress_tests/locustfile.py
@@ -265,5 +265,5 @@ def on_quit(environment: Environment, **kw: dict) -> None:
         logging.error('FAIL: p95 %.0fms > %dms', p95, _P95_THRESHOLD_MS)
         environment.process_exit_code = 1
     else:
+        # locust might set error exit code anyway in some circumstances
         logging.info('PASS')
-        environment.process_exit_code = 0

--- a/contribs/stress_tests/requirements.txt
+++ b/contribs/stress_tests/requirements.txt
@@ -1,0 +1,2 @@
+locust
+urllib3>=2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -81,3 +81,22 @@ commands =
     pytest -s {posargs:performance_suite/}
 allowlist_externals =
     make
+
+[testenv:load]
+skip_install = true
+deps = -rcontribs/stress_tests/requirements.txt
+change_dir = contribs/stress_tests
+pass_env =
+    WAZO_LOGIN
+    WAZO_PASSWORD
+    WAZO_TENANT
+    WAZO_HOST
+    WAZO_AUTH_HOST
+    WAZO_PROFILE
+    NUMBER_BASE
+    MOBILE_BASE
+    PHONEBOOK_COUNT
+    P95_THRESHOLD_MS
+    FAIL_RATIO_PCT
+commands =
+    locust -f locustfile.py -H {env:WAZO_HOST:http://localhost:9489} {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -81,22 +81,3 @@ commands =
     pytest -s {posargs:performance_suite/}
 allowlist_externals =
     make
-
-[testenv:load]
-skip_install = true
-deps = -rcontribs/stress_tests/requirements.txt
-change_dir = contribs/stress_tests
-pass_env =
-    WAZO_LOGIN
-    WAZO_PASSWORD
-    WAZO_TENANT
-    WAZO_HOST
-    WAZO_AUTH_HOST
-    WAZO_PROFILE
-    NUMBER_BASE
-    MOBILE_BASE
-    PHONEBOOK_COUNT
-    P95_THRESHOLD_MS
-    FAIL_RATIO_PCT
-commands =
-    locust -f locustfile.py -H {env:WAZO_HOST:http://localhost:9489} {posargs}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> New contribs-only tooling; no production service code changes. Scripts mutate tenant data only when run manually against a stack.
> 
> **Overview**
> Adds **Locust-based stress testing** for wazo-dird against a live stack, plus bash helpers to build the synthetic data those runs expect.
> 
> **`contribs/stress_tests/`** introduces three isolated scenarios (`GraphQLReverseLookupUser`, `LookupUser`, `FavoritesUser`), each hitting one directory service path so **ThreadPoolExecutor fan-out** (one future per profile source) can be measured separately. A shared token is minted at test start; quitting enforces configurable **p95** and **error-rate** gates. `.env.sample` and `requirements.txt` document configuration and deps.
> 
> **`contribs/scripts/`** adds an idempotent pipeline: **`create_synthetic_phonebook.sh`** (large CSV import, aligned with existing GraphQL load tests), **`create_phonebook_source.sh`** (N sources + display + profile for lookup/reverse/favorites), **`create_favorites.sh`** (seed per-source favorites for the test user), and **`add_source_to_profile.sh`** (append a source to an existing profile service such as `default` reverse).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d40ef7c58805332c4f274e9bfb5589c6ae4cf96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->