### PR TITLE
ITEM-498 fix reverse many first match overwrite

### DIFF
--- a/integration_tests/suite/test_core_functionality.py
+++ b/integration_tests/suite/test_core_functionality.py
@@ -172,6 +172,50 @@ class TestReverse(BaseMultipleSourceLauncher):
             any_of(self.alice_result, self.qwerty_result_1, self.qwerty_result_2),
         )
 
+    def _reverse_many_source_names(self, extens):
+        extens_literal = '[' + ', '.join(f'"{exten}"' for exten in extens) + ']'
+        query = {
+            'query': f'''
+            {{
+                user(uuid: "{VALID_UUID}") {{
+                    contacts(profile: "default", extens: {extens_literal}) {{
+                        edges {{
+                            node {{
+                                wazoSourceName
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+            ''',
+        }
+        response = self.dird.graphql.query(query)
+        edges = response['data']['user']['contacts']['edges']
+        return [
+            edge['node']['wazoSourceName'] if edge['node'] else None for edge in edges
+        ]
+
+    def test_reverse_many_keeps_first_source_match(self):
+        # third_csv, my_csv and second_csv all match exten 1111; reverse_many
+        # must keep whichever source answers first for a given exten, same
+        # as reverse(), instead of letting a later-completing source
+        # overwrite it.
+        with self.dird_with_config({'reverse_service': {'executor_workers': 1}}):
+            self.wait_strategy.wait(self.dird)
+
+            # a single-exten batch short-circuits on the first source to
+            # answer and cancels the rest, revealing the deterministic
+            # winner for this profile/executor configuration
+            (first_source,) = self._reverse_many_source_names(['1111'])
+
+            # 9999 never matches, so the loop can't break early and every
+            # source's result for 1111 gets folded into the aggregate,
+            # exercising the overwrite path
+            multi_source, unmatched = self._reverse_many_source_names(['1111', '9999'])
+
+        assert_that(multi_source, equal_to(first_source))
+        assert_that(unmatched, equal_to(None))
+
     def test_reverse_when_multi_columns(self):
         result = self.reverse('11112', 'default', VALID_UUID)
 

--- a/wazo_dird/plugins/reverse_service/plugin.py
+++ b/wazo_dird/plugins/reverse_service/plugin.py
@@ -97,7 +97,9 @@ class _ReverseService(helpers.BaseService):
         try:
             for future in as_completed(futures, timeout=timeout):
                 if result := future.result():
-                    results.update(result)
+                    for exten, source_result in result.items():
+                        if results.get(exten) is None:
+                            results[exten] = source_result
                     if all(result is not None for result in results.values()):
                         self._cancel_pending(futures)
                         break

--- a/wazo_dird/plugins/reverse_service/tests/test_reverse.py
+++ b/wazo_dird/plugins/reverse_service/tests/test_reverse.py
@@ -193,3 +193,28 @@ class TestReverseTimeout(unittest.TestCase):
         service.reverse_many(_PROFILE_WITH_SOURCE, ['1234'], 'test')
 
         future.cancel.assert_called_once()
+
+    @patch('wazo_dird.plugins.reverse_service.plugin.as_completed')
+    def test_reverse_many_keeps_first_match_when_sources_disagree(
+        self, mock_as_completed
+    ):
+        # a later-completing source must not overwrite an exten already
+        # matched by an earlier one, matching reverse()'s first-match-wins
+        exten_a, exten_b = '1111', '2222'
+        match_a1, match_a2, match_b = Mock(), Mock(), Mock()
+
+        first_future = Mock()
+        first_future.result.return_value = {exten_a: match_a1}
+        first_future.done.return_value = True
+
+        second_future = Mock()
+        second_future.result.return_value = {exten_a: match_a2, exten_b: match_b}
+        second_future.done.return_value = True
+
+        mock_as_completed.return_value = iter([first_future, second_future])
+        service, _ = _make_service_with_source()
+        setattr(service._executor, 'submit', Mock(return_value=Mock()))
+
+        results = service.reverse_many(_PROFILE_WITH_SOURCE, [exten_a, exten_b], 'test')
+
+        assert results == [match_a1, match_b]


### PR DESCRIPTION
- **fix(reverse): keep first source match in reverse_many**
- **test(integration): cover reverse_many first-match-wins**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core reverse lookup merging used by GraphQL batch contacts; behavior change for multi-source conflicts but aligns with existing reverse() semantics and is well covered by tests.
> 
> **Overview**
> **`reverse_many` no longer lets a slower source replace a contact already resolved for an extension**, aligning batch reverse lookups with single-extension `reverse()` first-match-wins behavior.
> 
> Aggregation now only assigns a result per exten when that slot is still empty, instead of merging source dicts with `update()` (which could overwrite the first hit). Unit and integration tests cover the disagreeing-sources case, including GraphQL `contacts(..., extens: [...])` when the batch cannot short-circuit early.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9f28998d21d8b5c1c94f51dfb30734b35da915b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->