### PR TITLE
docker: use pip install instead of setup.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,14 @@ RUN python3 -m venv /opt/venv
 # Activate virtual env
 ENV PATH="/opt/venv/bin:$PATH"
 
-RUN apt-get -q update
-RUN apt-get -yq install gcc libldap2-dev libsasl2-dev
+RUN apt-get -q update && apt-get -yq install gcc libldap2-dev libsasl2-dev
+
+WORKDIR /usr/src/wazo-dird
+COPY ./requirements.txt /usr/src/wazo-dird
+RUN pip3 install -r requirements.txt
 
 COPY . /usr/src/wazo-dird
-WORKDIR /usr/src/wazo-dird
-RUN pip3 install -r requirements.txt
-RUN python3 setup.py install
+RUN pip3 install .
 
 FROM python:3.11-slim-bookworm AS build-image
 COPY --from=compile-image /opt/venv /opt/venv

--- a/contribs/docker/Dockerfile-db
+++ b/contribs/docker/Dockerfile-db
@@ -6,7 +6,7 @@ WORKDIR /usr/src/wazo-dird
 ENV ALEMBIC_DB_URI=postgresql://wazo-dird:Secr7t@localhost/wazo-dird
 
 RUN true \
-    && python3 setup.py install \
+    && pip install . \
     && pg_start \
     && su postgres -c "psql -c \"CREATE ROLE \\"'"'"wazo-dird\\"'"'" LOGIN PASSWORD 'Secr7t';\"" \
     && su postgres -c "psql -c 'CREATE DATABASE \"wazo-dird\" WITH OWNER \"wazo-dird\";'" \

--- a/contribs/docker/Dockerfile-db
+++ b/contribs/docker/Dockerfile-db
@@ -6,7 +6,7 @@ WORKDIR /usr/src/wazo-dird
 ENV ALEMBIC_DB_URI=postgresql://wazo-dird:Secr7t@localhost/wazo-dird
 
 RUN true \
-    && pip install . \
+    && pip3 install . \
     && pg_start \
     && su postgres -c "psql -c \"CREATE ROLE \\"'"'"wazo-dird\\"'"'" LOGIN PASSWORD 'Secr7t';\"" \
     && su postgres -c "psql -c 'CREATE DATABASE \"wazo-dird\" WITH OWNER \"wazo-dird\";'" \


### PR DESCRIPTION
also optimize instructions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only Docker changes with no runtime application or security logic touched.
> 
> **Overview**
> Docker images for **wazo-dird** now install the package with **`pip3 install .`** instead of **`python3 setup.py install`** in both the main **`Dockerfile`** and **`contribs/docker/Dockerfile-db`**.
> 
> The main **`Dockerfile`** also tightens the compile stage for better layer caching: **`apt-get`** update/install is a single **`RUN`**, **`WORKDIR`** is set before copying only **`requirements.txt`**, dependencies are installed, then the full tree is copied and the package is installed with pip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 354955e07673f2232a9bc303c469b2b286f8d506. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->