### PR TITLE
remove performance jobs from zuul

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -6,11 +6,9 @@
     wazo-check:
       jobs:
         - dird-tox-integration
-        - dird-tox-performance
     wazo-gate:
       jobs:
         - dird-tox-integration
-        - dird-tox-performance
 
 - job:
     name: dird-tox-integration
@@ -18,13 +16,4 @@
     parent: wazo-tox-integration-py311
     timeout: 10800
     vars:
-      integration_test_timeout: 60
-
-- job:
-    name: dird-tox-performance
-    description: Run dird performance tests
-    parent: wazo-tox-integration-py311
-    timeout: 10800
-    vars:
-      tox_envlist: performance
       integration_test_timeout: 60


### PR DESCRIPTION
why: too unstable in CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that narrows test coverage; no application runtime behavior is modified.
> 
> **Overview**
> Removes the **`dird-tox-performance`** Zuul job definition and drops it from both **`wazo-check`** and **`wazo-gate`**, so CI no longer runs the dird performance tox suite.
> 
> Integration testing via **`dird-tox-integration`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a972f8638008cbbd8eef63b18dc993f8147a4bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->