### PR TITLE
ITEM-376 reverse: log timed out backends

### DIFF
--- a/integration_tests/assets/docker-compose.reverse_timeout.override.yml
+++ b/integration_tests/assets/docker-compose.reverse_timeout.override.yml
@@ -14,3 +14,6 @@ services:
     volumes:
       - "./scripts/asset.reverse_timeout.slow_ws.py:/tmp/ws.py"
     command: "python3 /tmp/ws.py"
+  dird:
+    volumes:
+      - "./tmp/data/asset.reverse_timeout.fast.csv:/tmp/data/fast.csv"

--- a/integration_tests/assets/tmp/data/asset.reverse_timeout.fast.csv
+++ b/integration_tests/assets/tmp/data/asset.reverse_timeout.fast.csv
@@ -1,0 +1,2 @@
+number,firstname,lastname
+5559999999,Bob,Fast

--- a/integration_tests/suite/test_reverse_timeout.py
+++ b/integration_tests/suite/test_reverse_timeout.py
@@ -1,7 +1,16 @@
 # Copyright 2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, equal_to, none, not_
+from hamcrest import (
+    assert_that,
+    contains,
+    contains_string,
+    equal_to,
+    has_entries,
+    has_entry,
+    none,
+    not_,
+)
 
 from .helpers.base import BaseDirdIntegrationTest
 from .helpers.config import Config
@@ -9,6 +18,7 @@ from .helpers.constants import VALID_UUID
 
 _SLOW_WS_NUMBER = '5551234567'
 _SLOW_WS_URL = 'http://ws:9485/ws'
+_FAST_CSV_NUMBER = '5559999999'
 
 _DEFAULT_DISPLAY = {
     'name': 'default_display',
@@ -30,6 +40,14 @@ def new_reverse_timeout_config(Session):
         first_matched_columns=['number'],
         format_columns={'reverse': '{firstname} {lastname}'},
     )
+    config.with_source(
+        backend='csv',
+        name='fast_csv',
+        file='/tmp/data/fast.csv',
+        separator=',',
+        first_matched_columns=['number'],
+        format_columns={'reverse': '{firstname} {lastname}'},
+    )
     config.with_profile(
         name='reverse-short-timeout',
         display='default_display',
@@ -47,6 +65,16 @@ def new_reverse_timeout_config(Session):
             'reverse': {
                 'sources': ['slow_ws'],
                 'options': {'timeout': 5},
+            }
+        },
+    )
+    config.with_profile(
+        name='reverse-many-short-timeout',
+        display='default_display',
+        services={
+            'reverse': {
+                'sources': ['slow_ws', 'fast_csv'],
+                'options': {'timeout': 0.1},
             }
         },
     )
@@ -75,3 +103,38 @@ class TestReverseServiceTimeout(BaseDirdIntegrationTest):
 
         assert_that(result['display'], not_(none()))
         assert_that(result['display'], equal_to('Alice Timeout'))
+
+    def test_reverse_many_with_short_timeout_returns_partial_and_logs_incomplete_source(
+        self,
+    ) -> None:
+        query = {
+            'query': '''
+            {
+                me {
+                    contacts(
+                        profile: "reverse-many-short-timeout",
+                        extens: ["%s", "%s"]
+                    ) {
+                        edges {
+                            node {
+                                firstname
+                            }
+                        }
+                    }
+                }
+            }
+            '''
+            % (_FAST_CSV_NUMBER, _SLOW_WS_NUMBER),
+        }
+
+        with self.capture_logs(service_name='dird') as logs:
+            response = self.dird.graphql.query(query)
+
+        assert_that(
+            response['data']['me']['contacts']['edges'],
+            contains(
+                has_entry('node', has_entries({'firstname': 'Bob'})),
+                has_entry('node', none()),
+            ),
+        )
+        assert_that(logs.result(), contains_string('incomplete=[\'slow_ws\']'))

--- a/wazo_dird/plugins/reverse_service/plugin.py
+++ b/wazo_dird/plugins/reverse_service/plugin.py
@@ -74,7 +74,7 @@ class _ReverseService(helpers.BaseService):
         token: str | None = None,
     ) -> list[SourceResult | None]:
         args = args or {}
-        futures = []
+        futures: list[Future[dict[str, SourceResult] | None]] = []
         sources = self.source_from_profile(profile_config)
         logger.debug(
             'Reverse lookup for %s in sources %s',
@@ -94,8 +94,10 @@ class _ReverseService(helpers.BaseService):
         ) or 1
 
         results: dict[str, SourceResult | None] = {exten: None for exten in extens}
+        completed_sources = set()
         try:
             for future in as_completed(futures, timeout=timeout):
+                completed_sources.add(getattr(future, 'name'))
                 if result := future.result():
                     for exten, source_result in result.items():
                         if results.get(exten) is None:
@@ -104,9 +106,15 @@ class _ReverseService(helpers.BaseService):
                         self._cancel_pending(futures)
                         break
         except TimeoutError:
+            incomplete_matches = [
+                getattr(future, 'name')
+                for future in futures
+                if getattr(future, 'name') not in completed_sources
+            ]
             logger.warning(
-                'Timeout on reverse many lookup, returning partial results (extens=%s)',
+                'Timeout on reverse many lookup, returning partial results (extens=%s, incomplete=%s)',
                 extens,
+                incomplete_matches,
             )
             self._cancel_pending(futures)
         return [value for value in results.values()]

--- a/wazo_dird/plugins/reverse_service/plugin.py
+++ b/wazo_dird/plugins/reverse_service/plugin.py
@@ -141,7 +141,7 @@ class _ReverseService(helpers.BaseService):
         token: str | None = None,
     ) -> SourceResult | None:
         args = args or {}
-        futures = []
+        futures: list[Future[SourceResult | None]] = []
         sources = self.source_from_profile(profile_config)
         logger.debug(
             'Reverse lookup for %s in sources %s',
@@ -160,13 +160,24 @@ class _ReverseService(helpers.BaseService):
             'timeout'
         ) or 1
 
+        completed_sources = set()
         try:
             for future in as_completed(futures, timeout=timeout):
+                completed_sources.add(getattr(future, 'name'))
                 if result := future.result():
                     self._cancel_pending(futures)
                     return result
         except TimeoutError:
-            logger.warning('Timeout on reverse lookup for exten: %s', exten)
+            incomplete_matches = [
+                getattr(future, 'name')
+                for future in futures
+                if getattr(future, 'name') not in completed_sources
+            ]
+            logger.warning(
+                'Timeout on reverse lookup for exten: %s, incomplete=%s',
+                exten,
+                incomplete_matches,
+            )
             self._cancel_pending(futures)
 
     def _async_reverse(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only change to warning log messages; lookup and timeout semantics are unchanged.
> 
> **Overview**
> When a reverse profile’s **timeout** fires before all backends finish, timeout warnings now include an **`incomplete`** list of source names that did not complete (for both single **`reverse`** and **`reverse_many`** lookups). Behavior is unchanged: partial results are still returned and pending tasks are still cancelled.
> 
> Integration coverage adds a **fast CSV** source alongside the existing slow WebSocket mock, a multi-source short-timeout profile, and a GraphQL test that expects one resolved contact, one missing node, and a log line naming **`slow_ws`** as incomplete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea9bf69acc3b09a06d84095e9d84c4101e9e19df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->