### PR TITLE
integration tests: use suite/ as default pytest target scope

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -14,9 +14,7 @@ egg-info:
 	cd .. && python3 setup.py egg_info
 	cd docker/broken-plugins && python3 setup.py egg_info
 
-PYTEST_TARGET=suite/
-PYTEST_FLAGS=
 test:
-	pytest $(PYTEST_FLAGS) $(PWD)/$(PYTEST_TARGET)
+	pytest suite
 
 .PHONY: test-setup build-dird build-db-image egg-info test

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -14,7 +14,9 @@ egg-info:
 	cd .. && python3 setup.py egg_info
 	cd docker/broken-plugins && python3 setup.py egg_info
 
+PYTEST_TARGET=suite/
+PYTEST_FLAGS=
 test:
-	pytest
+	pytest $(PYTEST_FLAGS) $(PWD)/$(PYTEST_TARGET)
 
 .PHONY: test-setup build-dird build-db-image egg-info test


### PR DESCRIPTION
why: default invocation should correspond to integration tests only, avoiding other test suites

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Makefile line change with no runtime or production impact; only narrows which tests run by default.
> 
> **Overview**
> **`make test`** in `integration_tests` now runs **`pytest suite`** instead of **`pytest`**, so the default integration test run only collects tests under **`suite/`** and no longer picks up other pytest collections elsewhere in the tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9966b12e791515ff8a00b937fda2db9a6f7897d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->