### PR TITLE
[ITEM-505] Fix office365 None value traceback

### DIFF
--- a/integration_tests/suite/test_office365_backend.py
+++ b/integration_tests/suite/test_office365_backend.py
@@ -47,6 +47,34 @@ OFFICE365_CONTACTS = {
     ]
 }
 
+# Microsoft Graph returns an explicit null for unset properties, so the key is
+# present with a None value. Two matching contacts are needed to make the sort
+# actually compare the values.
+OFFICE365_CONTACTS_WITHOUT_GIVEN_NAME = {
+    "value": [
+        {
+            "@odata.etag": "W/\"an-odata-etag\"",
+            "id": "an-id",
+            "displayName": "Wario Bros",
+            "givenName": "Wario",
+            "surname": "Bros",
+            "mobilePhone": "",
+            "businessPhones": ['5555555555'],
+            "emailAddresses": [{"address": "wbros@wazoquebec.onmicrosoft.com"}],
+        },
+        {
+            "@odata.etag": "W/\"another-odata-etag\"",
+            "id": "another-id",
+            "displayName": "Bros",
+            "givenName": None,
+            "surname": "Bros",
+            "mobilePhone": "",
+            "businessPhones": ['5555555556'],
+            "emailAddresses": [{"address": "bros@wazoquebec.onmicrosoft.com"}],
+        },
+    ]
+}
+
 
 class BaseOffice365TestCase(DirdAssetRunningTestCase):
     service = 'dird'
@@ -156,6 +184,31 @@ class TestOffice365Plugin(BaseOffice365PluginTestCase):
                     email='wbros@wazoquebec.onmicrosoft.com',
                     **self.WARIO,
                 )
+            ),
+        )
+
+    @fixtures.office365_result(OFFICE365_CONTACTS_WITHOUT_GIVEN_NAME)
+    def test_plugin_lookup_when_given_name_is_none(self, office365_api):
+        self.auth_mock.set_external_auth(self.MICROSOFT_EXTERNAL_AUTH)
+
+        result = self.backend.search('bros', self.LOOKUP_ARGS)
+
+        # sorted on "givenName": the None value is treated as an empty string
+        assert_that(
+            result,
+            contains_exactly(
+                has_entries(
+                    givenName=None,
+                    surname='Bros',
+                    number='5555555556',
+                    email='bros@wazoquebec.onmicrosoft.com',
+                ),
+                has_entries(
+                    givenName='Wario',
+                    surname='Bros',
+                    number='5555555555',
+                    email='wbros@wazoquebec.onmicrosoft.com',
+                ),
             ),
         )
 
@@ -286,6 +339,26 @@ class TestDirdOffice365Plugin(BaseOffice365TestCase):
             has_entries(
                 results=contains_exactly(
                     has_entries(column_values=contains_exactly('Wario'))
+                )
+            ),
+        )
+
+    @fixtures.office365_result(OFFICE365_CONTACTS_WITHOUT_GIVEN_NAME)
+    def test_given_none_given_name_when_lookup_then_contacts_fetched(
+        self, office365_api
+    ):
+        self.auth_client_mock.set_external_auth(self.MICROSOFT_EXTERNAL_AUTH)
+
+        result = self.client.directories.lookup(term='bros', profile='default')
+
+        # a raising source is swallowed by the lookup service, so a regression
+        # here shows up as an empty result set rather than an error
+        assert_that(
+            result,
+            has_entries(
+                results=contains_exactly(
+                    has_entries(column_values=contains_exactly(None)),
+                    has_entries(column_values=contains_exactly('Wario')),
                 )
             ),
         )

--- a/integration_tests/suite/test_office365_contacts.py
+++ b/integration_tests/suite/test_office365_contacts.py
@@ -260,7 +260,7 @@ class TestOffice365ContactList(BaseOffice365AssetTestCase):
 
     @fixtures.office365_result(OFFICE365_CONTACT_LIST)
     def test_search(self, office365_api):
-        self.list_(self.client, self.source_uuid, search='mario'),
+        _ = (self.list_(self.client, self.source_uuid, search='mario'),)
         office365_api.verify(
             {
                 'method': 'GET',

--- a/wazo_dird/plugins/office365_backend/plugin.py
+++ b/wazo_dird/plugins/office365_backend/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -84,6 +84,7 @@ class Office365Plugin(BaseSourcePlugin):
             return []
 
         updated_contacts = self._update_contact_fields(contacts)
+        logger.debug("All contacts: %s", updated_contacts)
         lowered_term = term.lower()
 
         def match_fn(contact: dict[str, Any]) -> bool:
@@ -94,6 +95,7 @@ class Office365Plugin(BaseSourcePlugin):
             return False
 
         filtered_contacts = [c for c in updated_contacts if match_fn(c)]
+        logger.debug("Filtered contacts: %s", filtered_contacts)
 
         # Note(achohra): We need to make sure that `givenName` key/value exists to avoid TypeError when sorting
 
@@ -101,7 +103,7 @@ class Office365Plugin(BaseSourcePlugin):
             field_name: str,
         ) -> Callable[[dict[str, Any]], Any]:
             def g(obj: dict[str, Any]) -> Any:
-                return obj.get(field_name, '')
+                return obj.get(field_name) or ''
 
             return g
 

--- a/wazo_dird/plugins/office365_backend/services.py
+++ b/wazo_dird/plugins/office365_backend/services.py
@@ -118,8 +118,12 @@ class Office365Service:
 
 
 def get_microsoft_access_token(
-    user_uuid: str, wazo_token: str, **auth_config: Any
+    user_uuid: str | None, wazo_token: str, **auth_config: Any
 ) -> str | None:
+    if not user_uuid:
+        logger.debug('User UUID is None')
+        raise MicrosoftTokenNotFoundException('user_uuid is empty or None')
+
     try:
         auth = Auth(token=wazo_token, **auth_config)
         access_token: str | None = auth.external.get('microsoft', user_uuid).get(


### PR DESCRIPTION
- **office365_backend: fix None value handling**


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted null-handling in Office365 search sort and an early guard on token lookup; behavior change is limited to contacts with null names and missing user UUID.
> 
> **Overview**
> Fixes **Office365 directory lookup** failing when Microsoft Graph returns contacts with an explicit **`givenName: null`** (unset fields are present with `None`, not omitted). Search results are sorted by `givenName`; the sort key now uses **`obj.get(field_name) or ''`** instead of **`get(..., '')`**, so `None` is treated like an empty string and Python no longer raises **`TypeError`** comparing `str` and `NoneType`. Without this, lookup can fail silently at the service layer and return **empty results**.
> 
> **`get_microsoft_access_token`** now accepts optional `user_uuid` and **raises `MicrosoftTokenNotFoundException`** when it is missing, instead of calling auth with a bad user id.
> 
> Integration tests cover plugin search and full **dird lookup** with a contact that has **`givenName: None`**, including expected sort order. Minor test tweak in **`test_office365_contacts`** so the search test still triggers the mocked API call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc1734d739cac779bc842cd1f3d32d5aa4090b92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->