### PR TITLE
Use nginx for internal wazo-auth requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 26.09
+
+* Requests to wazo-auth now default to `localhost:80`, through nginx. Existing
+  directory sources pointing at `localhost:9497` are migrated.
+
 ## 26.08
 
 * New `rest_api.min_threads` option: threads kept ready at all times.

--- a/alembic/versions/4f2c91ab07de_migrate_source_auth_to_nginx.py
+++ b/alembic/versions/4f2c91ab07de_migrate_source_auth_to_nginx.py
@@ -1,0 +1,47 @@
+"""migrate_source_auth_to_nginx
+
+Revision ID: 4f2c91ab07de
+Revises: 5a67556fbbf1
+
+"""
+
+import sqlalchemy as sa
+
+# alembic exposes op as a runtime proxy that mypy cannot see statically
+from alembic import op  # type: ignore[attr-defined]
+
+# revision identifiers, used by Alembic.
+revision = '4f2c91ab07de'
+down_revision = '5a67556fbbf1'
+
+_table = sa.table(
+    'dird_source',
+    sa.column('uuid', sa.String),
+    sa.column('extra_fields', sa.JSON),
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    rows = conn.execute(sa.select(_table)).fetchall()
+    for row in rows:
+        extra_fields = row.extra_fields
+        if not isinstance(extra_fields, dict):
+            continue
+        auth = extra_fields.get('auth')
+        if not isinstance(auth, dict):
+            continue
+        # sources pointing elsewhere are configured by the administrator
+        if auth.get('host') != 'localhost' or auth.get('port') != 9497:
+            continue
+        auth['port'] = 80
+        auth['prefix'] = '/api/auth'
+        conn.execute(
+            sa.update(_table)
+            .where(_table.c.uuid == row.uuid)
+            .values(extra_fields=extra_fields)
+        )
+
+
+def downgrade() -> None:
+    pass

--- a/etc/wazo-dird/config.yml
+++ b/etc/wazo-dird/config.yml
@@ -42,8 +42,7 @@ rest_api:
 # Authentication server connection settings
 auth:
   host: localhost
-  port: 9497
-  prefix: null
+  port: 80
   https: False
   key_file: /var/lib/wazo-auth-keys/wazo-dird-key.yml
 

--- a/etc/wazo-dird/templates.d/wazo_users.yml.jinja2
+++ b/etc/wazo-dird/templates.d/wazo_users.yml.jinja2
@@ -8,14 +8,14 @@ first_matched_columns:
 tenant_uuid: {{ tenant_uuid }}
 auth:
   host: {{ hostname }}
-  port: 9497
+  port: 443
   username: {{ service_id }}
   password: {{ service_key }}
+  https: true
   verify_certificate: false
 confd:
   host: {{ hostname }}
-  port: {{ port }}
-  version: "1.1"
+  port: 443
   https: true
   verify_certificate: false
 format_columns:

--- a/integration_tests/assets/etc/wazo-dird/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-dird/conf.d/50-default.yml
@@ -5,6 +5,8 @@ rest_api:
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
   username: dird-service
   password: dird-password
 

--- a/integration_tests/suite/test_auto_create.py
+++ b/integration_tests/suite/test_auto_create.py
@@ -63,8 +63,8 @@ class TestConfigAutoCreation(BaseDirdIntegrationTest):
                             name='auto_conference_mytenant',
                             auth={
                                 'host': 'localhost',
-                                'port': 9497,
-                                'prefix': None,
+                                'port': 80,
+                                'prefix': '/api/auth',
                                 'https': False,
                                 'version': '0.1',
                                 'key_file': key_file,
@@ -136,8 +136,8 @@ class TestConfigAutoCreation(BaseDirdIntegrationTest):
                             name='auto_google_mytenant',
                             auth={
                                 'host': 'localhost',
-                                'port': 9497,
-                                'prefix': None,
+                                'port': 80,
+                                'prefix': '/api/auth',
                                 'https': False,
                                 'version': '0.1',
                             },

--- a/wazo_dird/config.py
+++ b/wazo_dird/config.py
@@ -118,8 +118,7 @@ _DEFAULT_HTTPS_PORT = 9489
 _DEFAULT_CONFIG: Config = {
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
         'https': False,
         'key_file': '',
     },

--- a/wazo_dird/plugins/api/api.yml
+++ b/wazo_dird/plugins/api/api.yml
@@ -393,7 +393,7 @@ definitions:
       - properties:
           port:
             type: integer
-            default: 9497
+            default: 80
           version:
             type: string
             default: "0.1"

--- a/wazo_dird/plugins/config_service/plugin.py
+++ b/wazo_dird/plugins/config_service/plugin.py
@@ -45,8 +45,8 @@ DEFAULT_DISPLAY_COLUMNS = [
 CONFERENCE_SOURCE_BODY = {
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
+        'prefix': '/api/auth',
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-dird-conference-backend-key.yml',
         'version': '0.1',
@@ -76,8 +76,8 @@ PERSONAL_SOURCE_BODY = {
 WAZO_SOURCE_BODY = {
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
+        'prefix': '/api/auth',
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-dird-wazo-backend-key.yml',
         'version': '0.1',
@@ -100,8 +100,8 @@ WAZO_SOURCE_BODY = {
 OFFICE_365_SOURCE_BODY = {
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
+        'prefix': '/api/auth',
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-dird-wazo-backend-key.yml',
         'version': '0.1',
@@ -125,8 +125,8 @@ OFFICE_365_SOURCE_BODY = {
 GOOGLE_SOURCE_BODY = {
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
+        'prefix': '/api/auth',
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-dird-wazo-backend-key.yml',
         'version': '0.1',

--- a/wazo_dird/plugins/google_backend/api.yml
+++ b/wazo_dird/plugins/google_backend/api.yml
@@ -94,8 +94,8 @@ paths:
             application/json:
               auth:
                 host: localhost
-                port: 9497
-                prefix: null
+                port: 80
+                prefix: /api/auth
                 https: false
                 version: 0.1
               format_columns:

--- a/wazo_dird/plugins/office365_backend/api.yml
+++ b/wazo_dird/plugins/office365_backend/api.yml
@@ -212,7 +212,7 @@ definitions:
       - properties:
           port:
             type: integer
-            default: 9497
+            default: 80
           key_file:
             type: string
             description: The path the the file containing the credentials


### PR DESCRIPTION
Points requests to wazo-auth at the nginx internal entry point
(`localhost:80`) instead of the wazo-auth process port, in both the Python
defaults and the shipped `config.yml` (the YAML is loaded on top of the Python
defaults, so both must change).

The `prefix` override is dropped rather than set: `wazo-auth-client` already
defaults to `/api/auth`.

Depends on:

* wazo-platform/wazo-nginx#23 — the internal entry point itself
* wazo-platform/wazo-auth#449 — the wazo-auth location served on it

Both must be deployed before this merges, otherwise internal auth calls 404.
Ticket: TASK-504

Notes:

* Integration test assets now pin `port: 9497` and `prefix: null` explicitly:
  their stacks have no nginx, and those values used to come from the defaults
  changed here.
* Directory sources store their own auth config: the templates now point at
  nginx and alembic revision `4f2c91ab07de` migrates the existing ones, leaving
  sources that point elsewhere untouched. Tested against a scratch postgres.
* The `prefix` is set explicitly to `/api/auth` there, since it is stored data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all internal auth traffic is routed and migrates stored source configs; requires nginx/wazo-auth changes to be deployed first or auth calls will 404.
> 
> **Overview**
> Routes internal **wazo-auth** traffic through nginx (`localhost:80` + `/api/auth`) instead of the direct process port `9497`.
> 
> Defaults in `config.py` and `config.yml` now use port `80` and drop the explicit `prefix: null` (the client already defaults to `/api/auth`). Auto-created source bodies and API docs are updated to match. An alembic migration rewrites existing `dird_source` auth configs that pointed at `localhost:9497`, leaving custom hosts/ports untouched.
> 
> The remote `wazo_users` template now targets port `443` with HTTPS. Integration test assets pin the old direct-auth settings because those stacks have no nginx.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 913cabdeafb55e3f9cdafdacfa9c4ba809123457. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->