### PR TITLE
fix warnings

### DIFF
--- a/integration_tests/suite/test_auto_create.py
+++ b/integration_tests/suite/test_auto_create.py
@@ -1,7 +1,13 @@
-# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, contains, contains_inanyorder, has_entries, has_item
+from hamcrest import (
+    assert_that,
+    contains_exactly,
+    contains_inanyorder,
+    has_entries,
+    has_item,
+)
 from wazo_test_helpers import until
 from wazo_test_helpers.auth import AuthClient as MockAuthClient
 from wazo_test_helpers.auth import MockUserToken
@@ -188,7 +194,7 @@ class TestConfigAutoCreation(BaseDirdIntegrationTest):
             assert_that(
                 result,
                 has_entries(
-                    column_headers=contains(
+                    column_headers=contains_exactly(
                         'Nom',
                         'Prénom',
                         'Nom de famille',
@@ -198,7 +204,7 @@ class TestConfigAutoCreation(BaseDirdIntegrationTest):
                         'Favoris',
                         'E-mail',
                     ),
-                    column_types=contains(
+                    column_types=contains_exactly(
                         'name',
                         'firstname',
                         'lastname',
@@ -210,7 +216,7 @@ class TestConfigAutoCreation(BaseDirdIntegrationTest):
                     ),
                     results=contains_inanyorder(
                         has_entries(
-                            column_values=contains(
+                            column_values=contains_exactly(
                                 'Alice', 'Alice', None, '1234', None, None, False, None
                             )
                         )

--- a/integration_tests/suite/test_backends.py
+++ b/integration_tests/suite/test_backends.py
@@ -1,7 +1,7 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, contains, contains_inanyorder, has_entries
+from hamcrest import assert_that, contains_exactly, contains_inanyorder, has_entries
 
 from .helpers.base import BaseDirdIntegrationTest
 
@@ -32,7 +32,7 @@ class TestBackends(BaseDirdIntegrationTest):
         )
 
         result = self.client.backends.list(name='csv')
-        self._assert_matches(result, 9, 1, contains, 'csv')
+        self._assert_matches(result, 9, 1, contains_exactly, 'csv')
 
         result = self.client.backends.list(order='name', direction='asc')
         expected = [
@@ -46,7 +46,7 @@ class TestBackends(BaseDirdIntegrationTest):
             'phonebook',
             'wazo',
         ]
-        self._assert_matches(result, 9, 9, contains, *expected)
+        self._assert_matches(result, 9, 9, contains_exactly, *expected)
 
         result = self.client.backends.list(order='name', direction='desc')
         expected = [
@@ -60,16 +60,16 @@ class TestBackends(BaseDirdIntegrationTest):
             'csv',
             'conference',
         ]
-        self._assert_matches(result, 9, 9, contains, *expected)
+        self._assert_matches(result, 9, 9, contains_exactly, *expected)
 
         result = self.client.backends.list(limit=2, offset=5)
-        self._assert_matches(result, 9, 9, contains, 'office365', 'personal')
+        self._assert_matches(result, 9, 9, contains_exactly, 'office365', 'personal')
 
         result = self.client.backends.list(limit=2)
-        self._assert_matches(result, 9, 9, contains, 'conference', 'csv')
+        self._assert_matches(result, 9, 9, contains_exactly, 'conference', 'csv')
 
         result = self.client.backends.list(offset=7)
-        self._assert_matches(result, 9, 9, contains, 'phonebook', 'wazo')
+        self._assert_matches(result, 9, 9, contains_exactly, 'phonebook', 'wazo')
 
     @staticmethod
     def _assert_matches(result, total, filtered, matcher, *names):

--- a/integration_tests/suite/test_conference_backend.py
+++ b/integration_tests/suite/test_conference_backend.py
@@ -1,9 +1,15 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest.mock import Mock
 
-from hamcrest import assert_that, contains, contains_inanyorder, empty, has_entries
+from hamcrest import (
+    assert_that,
+    contains_exactly,
+    contains_inanyorder,
+    empty,
+    has_entries,
+)
 
 from .helpers.base import BaseDirdIntegrationTest, DirdAssetRunningTestCase
 from .helpers.config import new_conference_config
@@ -51,16 +57,16 @@ class TestConferencePlugin(DirdAssetRunningTestCase):
 
     def test_lookup_with_accent(self):
         result = self.backend.search('accent')
-        assert_that(result, contains(has_entries(displayname='accént')))
+        assert_that(result, contains_exactly(has_entries(displayname='accént')))
 
     def test_lookup_by_name(self):
         result = self.backend.search('daily')
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     displayname='daily scrum',
-                    extensions=contains('4002'),
+                    extensions=contains_exactly('4002'),
                     id=4,
                     incalls=empty(),
                     name='daily scrum',
@@ -74,10 +80,10 @@ class TestConferencePlugin(DirdAssetRunningTestCase):
         result = self.backend.search('4002')
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     displayname='daily scrum',
-                    extensions=contains('4002'),
+                    extensions=contains_exactly('4002'),
                     id=4,
                     incalls=empty(),
                     name='daily scrum',
@@ -91,12 +97,12 @@ class TestConferencePlugin(DirdAssetRunningTestCase):
         result = self.backend.search('1009')
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     displayname='test',
-                    extensions=contains('4001'),
+                    extensions=contains_exactly('4001'),
                     id=1,
-                    incalls=contains('1009'),
+                    incalls=contains_exactly('1009'),
                     name='test',
                     phone='4001',
                     reverse='test',
@@ -110,7 +116,7 @@ class TestConferencePlugin(DirdAssetRunningTestCase):
             result,
             has_entries(
                 displayname='daily scrum',
-                extensions=contains('4002'),
+                extensions=contains_exactly('4002'),
                 id=4,
                 incalls=empty(),
                 name='daily scrum',
@@ -125,9 +131,9 @@ class TestConferencePlugin(DirdAssetRunningTestCase):
             result,
             has_entries(
                 displayname='test',
-                extensions=contains('4001'),
+                extensions=contains_exactly('4001'),
                 id=1,
-                incalls=contains('1009'),
+                incalls=contains_exactly('1009'),
                 name='test',
                 phone='4001',
                 reverse='test',
@@ -162,4 +168,4 @@ class TestNoConfd(BaseDirdIntegrationTest):
 
     def test_given_no_confd_when_lookup_then_returns_no_results(self):
         result = self.lookup('daily', 'default')
-        assert_that(result['results'], contains())
+        assert_that(result['results'], contains_exactly())

--- a/integration_tests/suite/test_conference_http.py
+++ b/integration_tests/suite/test_conference_http.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from contextlib import contextmanager
@@ -8,7 +8,7 @@ import requests
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     equal_to,
     has_entries,
@@ -143,12 +143,12 @@ class TestList(BaseConferenceCRUDTestCase):
 
         assert_that(
             self.client.conference_source.list(name='abc'),
-            has_entries(items=contains(a), total=3, filtered=1),
+            has_entries(items=contains_exactly(a), total=3, filtered=1),
         )
 
         assert_that(
             self.client.conference_source.list(uuid=c['uuid']),
-            has_entries(items=contains(c), total=3, filtered=1),
+            has_entries(items=contains_exactly(c), total=3, filtered=1),
         )
 
         assert_that(
@@ -162,22 +162,22 @@ class TestList(BaseConferenceCRUDTestCase):
     def test_pagination(self, c, b, a):
         assert_that(
             self.client.conference_source.list(order='name'),
-            has_entries(items=contains(a, b, c), total=3, filtered=3),
+            has_entries(items=contains_exactly(a, b, c), total=3, filtered=3),
         )
 
         assert_that(
             self.client.conference_source.list(order='name', direction='desc'),
-            has_entries(items=contains(c, b, a), total=3, filtered=3),
+            has_entries(items=contains_exactly(c, b, a), total=3, filtered=3),
         )
 
         assert_that(
             self.client.conference_source.list(order='name', limit=2),
-            has_entries(items=contains(a, b), total=3, filtered=3),
+            has_entries(items=contains_exactly(a, b), total=3, filtered=3),
         )
 
         assert_that(
             self.client.conference_source.list(order='name', offset=2),
-            has_entries(items=contains(c), total=3, filtered=3),
+            has_entries(items=contains_exactly(c), total=3, filtered=3),
         )
 
     @fixtures.conference_source(name='abc', token=VALID_TOKEN_MAIN_TENANT)

--- a/integration_tests/suite/test_core_functionality.py
+++ b/integration_tests/suite/test_core_functionality.py
@@ -8,7 +8,7 @@ from hamcrest import (
     all_of,
     any_of,
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     contains_string,
     equal_to,
@@ -45,8 +45,8 @@ class TestSourceModification(BaseMultipleSourceLauncher):
         assert_that(
             response,
             has_entries(
-                results=contains(
-                    has_entries(column_values=contains('Alice', 'Alan', '1111'))
+                results=contains_exactly(
+                    has_entries(column_values=contains_exactly('Alice', 'Alan', '1111'))
                 )
             ),
         )
@@ -59,8 +59,10 @@ class TestSourceModification(BaseMultipleSourceLauncher):
         assert_that(
             response,
             has_entries(
-                results=contains(
-                    has_entries(column_values=contains('SUCCESS Alice', 'Alan', '1111'))
+                results=contains_exactly(
+                    has_entries(
+                        column_values=contains_exactly('SUCCESS Alice', 'Alan', '1111')
+                    )
                 )
             ),
         )
@@ -251,11 +253,11 @@ class TestLookupWhenASourceFails(HalfBrokenTestCase):
         assert_that(result['results'], has_length(2))
         assert_that(
             result['results'][0]['column_values'],
-            contains('Alice', 'AAA', '5555555555'),
+            contains_exactly('Alice', 'AAA', '5555555555'),
         )
         assert_that(
             result['results'][1]['column_values'],
-            contains('Alice', 'AAA', '5555555555'),
+            contains_exactly('Alice', 'AAA', '5555555555'),
         )
 
     def test_that_reverse_returns_a_result(self):
@@ -271,40 +273,50 @@ class TestDisplay(CSVWithMultipleDisplayTestCase):
         result = self.lookup('lice', 'default')
 
         assert_that(
-            result['column_headers'], contains('Firstname', 'Lastname', 'Number', None)
+            result['column_headers'],
+            contains_exactly('Firstname', 'Lastname', 'Number', None),
         )
-        assert_that(result['column_types'], contains(None, None, None, 'favorite'))
+        assert_that(
+            result['column_types'], contains_exactly(None, None, None, 'favorite')
+        )
 
     def test_display_with_a_type_only(self):
         result = self.lookup('lice', 'test')
 
         assert_that(
-            result['column_headers'], contains('fn', 'ln', 'Empty', None, 'Default')
+            result['column_headers'],
+            contains_exactly('fn', 'ln', 'Empty', None, 'Default'),
         )
         assert_that(
-            result['column_types'], contains('firstname', None, None, 'status', None)
+            result['column_types'],
+            contains_exactly('firstname', None, None, 'status', None),
         )
         assert_that(
             result['results'][0]['column_values'],
-            contains('Alice', 'AAA', None, None, 'Default'),
+            contains_exactly('Alice', 'AAA', None, None, 'Default'),
         )
 
     def test_that_the_display_is_applied_to_headers(self):
         result = self.headers('default')
 
         assert_that(
-            result['column_headers'], contains('Firstname', 'Lastname', 'Number', None)
+            result['column_headers'],
+            contains_exactly('Firstname', 'Lastname', 'Number', None),
         )
-        assert_that(result['column_types'], contains(None, None, None, 'favorite'))
+        assert_that(
+            result['column_types'], contains_exactly(None, None, None, 'favorite')
+        )
 
     def test_display_on_headers_with_no_title(self):
         result = self.headers('test')
 
         assert_that(
-            result['column_headers'], contains('fn', 'ln', 'Empty', None, 'Default')
+            result['column_headers'],
+            contains_exactly('fn', 'ln', 'Empty', None, 'Default'),
         )
         assert_that(
-            result['column_types'], contains('firstname', None, None, 'status', None)
+            result['column_types'],
+            contains_exactly('firstname', None, None, 'status', None),
         )
 
 
@@ -319,7 +331,9 @@ class Test404WhenUnknownProfile(CSVWithMultipleDisplayTestCase):
         assert_that(result.status_code, equal_to(404))
         assert_that(
             error['reason'],
-            contains(all_of(contains_string('profile'), contains_string('unknown'))),
+            contains_exactly(
+                all_of(contains_string('profile'), contains_string('unknown'))
+            ),
         )
 
     def test_that_headers_returns_404(self):
@@ -330,7 +344,9 @@ class Test404WhenUnknownProfile(CSVWithMultipleDisplayTestCase):
         assert_that(result.status_code, equal_to(404))
         assert_that(
             error['reason'],
-            contains(all_of(contains_string('profile'), contains_string('unknown'))),
+            contains_exactly(
+                all_of(contains_string('profile'), contains_string('unknown'))
+            ),
         )
 
     def test_that_favorites_returns_404(self):
@@ -341,7 +357,9 @@ class Test404WhenUnknownProfile(CSVWithMultipleDisplayTestCase):
         assert_that(result.status_code, equal_to(404))
         assert_that(
             error['reason'],
-            contains(all_of(contains_string('profile'), contains_string('unknown'))),
+            contains_exactly(
+                all_of(contains_string('profile'), contains_string('unknown'))
+            ),
         )
 
     def test_that_personal_returns_404(self):
@@ -354,5 +372,7 @@ class Test404WhenUnknownProfile(CSVWithMultipleDisplayTestCase):
         assert_that(result.status_code, equal_to(404))
         assert_that(
             error['reason'],
-            contains(all_of(contains_string('profile'), contains_string('unknown'))),
+            contains_exactly(
+                all_of(contains_string('profile'), contains_string('unknown'))
+            ),
         )

--- a/integration_tests/suite/test_csv_backend.py
+++ b/integration_tests/suite/test_csv_backend.py
@@ -1,11 +1,11 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
 import unittest
 
 import yaml
-from hamcrest import assert_that, contains, contains_inanyorder, has_entries
+from hamcrest import assert_that, contains_exactly, contains_inanyorder, has_entries
 
 from .helpers.base import BaseDirdIntegrationTest, CSVWithMultipleDisplayTestCase
 from .helpers.config import new_csv_with_pipes_config
@@ -40,7 +40,7 @@ class TestCSVBackend(CSVWithMultipleDisplayTestCase):
         favorite = [False]
         assert_that(
             response['results'],
-            contains(has_entries(column_values=self._alice + favorite)),
+            contains_exactly(has_entries(column_values=self._alice + favorite)),
         )
 
     def test_that_csv_file_changes_have_been_committed(self):
@@ -58,7 +58,9 @@ class TestCSVBackend(CSVWithMultipleDisplayTestCase):
             favorite = [False]
             assert_that(
                 response['results'],
-                contains(has_entries(column_values=updated_column_values + favorite)),
+                contains_exactly(
+                    has_entries(column_values=updated_column_values + favorite)
+                ),
             )
 
         finally:
@@ -89,7 +91,7 @@ class TestCSVBackend(CSVWithMultipleDisplayTestCase):
             favorite = [True]
             assert_that(
                 response['results'],
-                contains(
+                contains_exactly(
                     has_entries(column_values=self._alice + favorite),
                     has_entries(column_values=self._charles + favorite),
                 ),
@@ -111,7 +113,7 @@ class TestCSVNoUnique(_BaseCSVFileTestCase):
     def test_lookup_should_work_without_unique_column(self):
         result = self.backend.search('lice')
 
-        assert_that(result, contains(has_entries(**self._alice)))
+        assert_that(result, contains_exactly(has_entries(**self._alice)))
 
 
 class TestCSVWithAccents(_BaseCSVFileTestCase):
@@ -125,12 +127,12 @@ class TestCSVWithAccents(_BaseCSVFileTestCase):
     def test_lookup_with_accents_in_term(self):
         result = self.backend.search('pép')
 
-        assert_that(result, contains(has_entries(**self._pepe)))
+        assert_that(result, contains_exactly(has_entries(**self._pepe)))
 
     def test_lookup_with_accents_in_the_result(self):
         result = self.backend.search('lol')
 
-        assert_that(result, contains(has_entries(**self._pepe)))
+        assert_that(result, contains_exactly(has_entries(**self._pepe)))
 
 
 class TestCSVSeparator(BaseDirdIntegrationTest):
@@ -143,6 +145,8 @@ class TestCSVSeparator(BaseDirdIntegrationTest):
         assert_that(
             result['results'],
             contains_inanyorder(
-                has_entries(column_values=contains('Alice', 'AAA', '5555555555'))
+                has_entries(
+                    column_values=contains_exactly('Alice', 'AAA', '5555555555')
+                )
             ),
         )

--- a/integration_tests/suite/test_csv_http.py
+++ b/integration_tests/suite/test_csv_http.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from contextlib import contextmanager
@@ -8,7 +8,7 @@ from unittest.mock import ANY
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     equal_to,
     has_entries,
@@ -113,12 +113,12 @@ class TestList(BaseCSVCRUDTestCase):
 
         assert_that(
             self.client.csv_source.list(name='abc'),
-            has_entries(items=contains(a), total=3, filtered=1),
+            has_entries(items=contains_exactly(a), total=3, filtered=1),
         )
 
         assert_that(
             self.client.csv_source.list(uuid=c['uuid']),
-            has_entries(items=contains(c), total=3, filtered=1),
+            has_entries(items=contains_exactly(c), total=3, filtered=1),
         )
 
         result = self.client.csv_source.list(search='b')
@@ -132,22 +132,22 @@ class TestList(BaseCSVCRUDTestCase):
     def test_pagination(self, c, b, a):
         assert_that(
             self.client.csv_source.list(order='name'),
-            has_entries(items=contains(a, b, c), total=3, filtered=3),
+            has_entries(items=contains_exactly(a, b, c), total=3, filtered=3),
         )
 
         assert_that(
             self.client.csv_source.list(order='name', direction='desc'),
-            has_entries(items=contains(c, b, a), total=3, filtered=3),
+            has_entries(items=contains_exactly(c, b, a), total=3, filtered=3),
         )
 
         assert_that(
             self.client.csv_source.list(order='name', limit=2),
-            has_entries(items=contains(a, b), total=3, filtered=3),
+            has_entries(items=contains_exactly(a, b), total=3, filtered=3),
         )
 
         assert_that(
             self.client.csv_source.list(order='name', offset=2),
-            has_entries(items=contains(c), total=3, filtered=3),
+            has_entries(items=contains_exactly(c), total=3, filtered=3),
         )
 
     @fixtures.csv_source(name='abc', token=VALID_TOKEN_MAIN_TENANT)

--- a/integration_tests/suite/test_csv_ws_backend.py
+++ b/integration_tests/suite/test_csv_ws_backend.py
@@ -1,7 +1,7 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, contains, empty, has_entries
+from hamcrest import assert_that, contains_exactly, empty, has_entries
 
 from .helpers.base import DirdAssetRunningTestCase
 from .helpers.utils import BackendWrapper
@@ -47,12 +47,12 @@ class TestCSVWSBackend(_BaseCSVWSBackend):
     def test_that_verify_certificate_false(self):
         results = self.backend.search('Ben')
 
-        assert_that(results, contains(has_entries(**self._benoit)))
+        assert_that(results, contains_exactly(has_entries(**self._benoit)))
 
     def test_that_searching_for_result_with_non_ascii(self):
         results = self.backend.search('dré')
 
-        assert_that(results, contains(has_entries(**self._andree_anne)))
+        assert_that(results, contains_exactly(has_entries(**self._andree_anne)))
 
     def test_reverse_lookup(self):
         result = self.backend.first('5551231111')
@@ -69,7 +69,7 @@ class TestCSVWSBackend(_BaseCSVWSBackend):
 
         result = self.backend.list([self._benoit['id'], unknown_id])
 
-        assert_that(result, contains(has_entries(**self._benoit)))
+        assert_that(result, contains_exactly(has_entries(**self._benoit)))
 
 
 class TestCSVWSBackendComa(_BaseCSVWSBackend):
@@ -104,7 +104,7 @@ class TestCSVWSBackendComa(_BaseCSVWSBackend):
     def test_that_searching_for_result_with_non_ascii(self):
         results = self.backend.search('dré')
 
-        assert_that(results, contains(has_entries(**self._andree_anne)))
+        assert_that(results, contains_exactly(has_entries(**self._andree_anne)))
 
     def test_that_no_result_returns_an_empty_list(self):
         results = self.backend.search('henry')
@@ -116,4 +116,4 @@ class TestCSVWSBackendComa(_BaseCSVWSBackend):
 
         result = self.backend.list([self._benoit['id'], unknown_id])
 
-        assert_that(result, contains(has_entries(**self._benoit)))
+        assert_that(result, contains_exactly(has_entries(**self._benoit)))

--- a/integration_tests/suite/test_csv_ws_http.py
+++ b/integration_tests/suite/test_csv_ws_http.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from contextlib import contextmanager
@@ -8,7 +8,7 @@ from unittest.mock import ANY
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     equal_to,
     has_entries,
@@ -115,12 +115,12 @@ class TestList(BaseCSVWSCRUDTestCase):
 
         assert_that(
             self.client.csv_ws_source.list(name='abc'),
-            has_entries(items=contains(a), total=3, filtered=1),
+            has_entries(items=contains_exactly(a), total=3, filtered=1),
         )
 
         assert_that(
             self.client.csv_ws_source.list(uuid=c['uuid']),
-            has_entries(items=contains(c), total=3, filtered=1),
+            has_entries(items=contains_exactly(c), total=3, filtered=1),
         )
 
         result = self.client.csv_ws_source.list(search='b')
@@ -134,22 +134,22 @@ class TestList(BaseCSVWSCRUDTestCase):
     def test_pagination(self, c, b, a):
         assert_that(
             self.client.csv_ws_source.list(order='name'),
-            has_entries(items=contains(a, b, c), total=3, filtered=3),
+            has_entries(items=contains_exactly(a, b, c), total=3, filtered=3),
         )
 
         assert_that(
             self.client.csv_ws_source.list(order='name', direction='desc'),
-            has_entries(items=contains(c, b, a), total=3, filtered=3),
+            has_entries(items=contains_exactly(c, b, a), total=3, filtered=3),
         )
 
         assert_that(
             self.client.csv_ws_source.list(order='name', limit=2),
-            has_entries(items=contains(a, b), total=3, filtered=3),
+            has_entries(items=contains_exactly(a, b), total=3, filtered=3),
         )
 
         assert_that(
             self.client.csv_ws_source.list(order='name', offset=2),
-            has_entries(items=contains(c), total=3, filtered=3),
+            has_entries(items=contains_exactly(c), total=3, filtered=3),
         )
 
     @fixtures.csv_ws_source(name='abc', token=VALID_TOKEN_MAIN_TENANT)

--- a/integration_tests/suite/test_database.py
+++ b/integration_tests/suite/test_database.py
@@ -12,7 +12,7 @@ from hamcrest import (
     any_of,
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -224,7 +224,7 @@ class TestDisplayCRUD(_BaseTest):
                     uuid=uuid_(),
                     tenant_uuid=tenant_uuid,
                     name=name,
-                    columns=contains(
+                    columns=contains_exactly(
                         has_entries(field='firstname', title='Firstname'),
                         has_entries(field='lastname', title='Lastname', default=''),
                         has_entries(field='number', title='Number', type='number'),
@@ -1113,7 +1113,7 @@ class TestContactCRUD(_BaseTest):
         assert_that(result, equal_to(expected(self.contact_1)))
 
         contact_list = self._crud.list_personal_contacts(owner)
-        assert_that(contact_list, contains(expected(self.contact_1)))
+        assert_that(contact_list, contains_exactly(expected(self.contact_1)))
 
     @with_user_uuid
     def test_that_create_personal_contact_creates_with_existing_owner(self, user_uuid):
@@ -1123,7 +1123,7 @@ class TestContactCRUD(_BaseTest):
         assert_that(result, equal_to(expected(self.contact_1)))
 
         contact_list = self._crud.list_personal_contacts(user_uuid)
-        assert_that(contact_list, contains(expected(self.contact_1)))
+        assert_that(contact_list, contains_exactly(expected(self.contact_1)))
 
     @with_user_uuid
     def test_that_personal_contacts_are_unique(self, user_uuid):
@@ -1529,7 +1529,10 @@ class TestPersonalContactSearchEngine(_BaseTest):
         result = engine.find_first_personal_contact(user_uuid, '5555550001')
 
         assert_that(
-            result, contains(any_of(expected(self.contact_2), expected(self.contact_3)))
+            result,
+            contains_exactly(
+                any_of(expected(self.contact_2), expected(self.contact_3))
+            ),
         )
 
     @with_user_uuid
@@ -1549,10 +1552,10 @@ class TestPersonalContactSearchEngine(_BaseTest):
         )
 
         result = engine.list_personal_contacts(user_uuid, ids[:1])
-        assert_that(result, contains(expected(self.contact_1)))
+        assert_that(result, contains_exactly(expected(self.contact_1)))
 
         result = engine.list_personal_contacts(user_uuid, ids[1:])
-        assert_that(result, contains(expected(self.contact_2)))
+        assert_that(result, contains_exactly(expected(self.contact_2)))
 
     @with_user_uuid
     @with_user_uuid
@@ -1628,10 +1631,10 @@ class TestPersonalContactSearchEngine(_BaseTest):
         self._insert_personal_contacts(user_uuid, self.contact_1, self.contact_2)
 
         result = engine.find_personal_contacts(user_uuid, 'ced')
-        assert_that(result, contains(expected(self.contact_2)))
+        assert_that(result, contains_exactly(expected(self.contact_2)))
 
         result = engine.find_personal_contacts(user_uuid, 'céd')
-        assert_that(result, contains(expected(self.contact_2)))
+        assert_that(result, contains_exactly(expected(self.contact_2)))
 
     @with_user_uuid
     def test_that_find_searches_only_in_searched_columns(self, user_uuid):
@@ -1687,14 +1690,16 @@ class TestProfileCRUD(_BaseTest):
                     display=has_entries(uuid=display['uuid']),
                     services=has_entries(
                         lookup=has_entries(
-                            sources=contains(
+                            sources=contains_exactly(
                                 has_entries(uuid=source_1['uuid']),
                                 has_entries(uuid=source_2['uuid']),
                             ),
                             timeout=5,
                         ),
                         reverse=has_entries(
-                            sources=contains(has_entries(uuid=source_2['uuid'])),
+                            sources=contains_exactly(
+                                has_entries(uuid=source_2['uuid'])
+                            ),
                             timeout=0.5,
                         ),
                     ),

--- a/integration_tests/suite/test_dird_phonebook_backend.py
+++ b/integration_tests/suite/test_dird_phonebook_backend.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import random
@@ -8,7 +8,7 @@ from typing import cast
 from unittest.mock import Mock
 from uuid import uuid4
 
-from hamcrest import assert_that, contains, contains_inanyorder, equal_to
+from hamcrest import assert_that, contains_exactly, contains_inanyorder, equal_to
 
 from wazo_dird import database
 from wazo_dird.database.queries.base import ContactInfo as _ContactInfo
@@ -124,7 +124,7 @@ class TestPhonebookBackend(unittest.TestCase):
     def test_that_searching_for_grid_returns_agrid(self):
         result = self.backend.search('grid')
 
-        assert_that(result, contains(self.hagrid))
+        assert_that(result, contains_exactly(self.hagrid))
 
     def test_that_first_match_returns_a_contact(self):
         result = self.backend.first(self.draco['number'])

--- a/integration_tests/suite/test_displays.py
+++ b/integration_tests/suite/test_displays.py
@@ -7,7 +7,7 @@ import requests
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     equal_to,
     has_entries,
@@ -143,10 +143,10 @@ class TestList(BaseDisplayTestCase):
         )
 
         result = self.client.displays.list(name='abc')
-        self.assert_list_result(result, contains(a), total=3, filtered=1)
+        self.assert_list_result(result, contains_exactly(a), total=3, filtered=1)
 
         result = self.client.displays.list(uuid=c['uuid'])
-        self.assert_list_result(result, contains(c), total=3, filtered=1)
+        self.assert_list_result(result, contains_exactly(c), total=3, filtered=1)
 
         result = self.client.displays.list(search='b')
         self.assert_list_result(result, contains_inanyorder(a, b), total=3, filtered=2)
@@ -170,10 +170,10 @@ class TestList(BaseDisplayTestCase):
         self.assert_list_result(result, contains_inanyorder(c), total=1, filtered=1)
 
         result = sub_tenant_client.displays.list()
-        self.assert_list_result(result, contains(c), total=1, filtered=1)
+        self.assert_list_result(result, contains_exactly(c), total=1, filtered=1)
 
         result = sub_tenant_client.displays.list(recurse=True)
-        self.assert_list_result(result, contains(c), total=1, filtered=1)
+        self.assert_list_result(result, contains_exactly(c), total=1, filtered=1)
 
         assert_that(
             calling(sub_tenant_client.displays.list).with_args(tenant_uuid=MAIN_TENANT),
@@ -187,16 +187,16 @@ class TestList(BaseDisplayTestCase):
     @fixtures.display(name='cde')
     def test_pagination(self, c, b, a):
         result = self.client.displays.list(order='name')
-        self.assert_list_result(result, contains(a, b, c), total=3, filtered=3)
+        self.assert_list_result(result, contains_exactly(a, b, c), total=3, filtered=3)
 
         result = self.client.displays.list(order='name', direction='desc')
-        self.assert_list_result(result, contains(c, b, a), total=3, filtered=3)
+        self.assert_list_result(result, contains_exactly(c, b, a), total=3, filtered=3)
 
         result = self.client.displays.list(order='name', limit=2)
-        self.assert_list_result(result, contains(a, b), total=3, filtered=3)
+        self.assert_list_result(result, contains_exactly(a, b), total=3, filtered=3)
 
         result = self.client.displays.list(order='name', offset=2)
-        self.assert_list_result(result, contains(c), total=3, filtered=3)
+        self.assert_list_result(result, contains_exactly(c), total=3, filtered=3)
 
 
 class TestPost(BaseDisplayTestCase):
@@ -233,7 +233,7 @@ class TestPost(BaseDisplayTestCase):
                 has_entries(
                     uuid=uuid_(),
                     tenant_uuid=MAIN_TENANT,
-                    columns=contains(
+                    columns=contains_exactly(
                         has_entries(
                             field='fn',
                             title='Firstname',
@@ -325,7 +325,7 @@ class TestPut(BaseDisplayTestCase):
                 uuid=display['uuid'],
                 tenant_uuid=display['tenant_uuid'],
                 name=self.valid_body['name'],
-                columns=contains(
+                columns=contains_exactly(
                     has_entries(self.valid_body['columns'][0]),
                     has_entries(self.valid_body['columns'][1]),
                 ),

--- a/integration_tests/suite/test_favorites.py
+++ b/integration_tests/suite/test_favorites.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 from hamcrest import (
     any_of,
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     equal_to,
     has_entries,
@@ -72,10 +72,12 @@ class TestFavorites(_BaseMultiTokenFavoriteTest):
             result['results'],
             contains_inanyorder(
                 has_entry(
-                    'column_values', contains('Alice', 'AAA', '5555555555', True)
+                    'column_values',
+                    contains_exactly('Alice', 'AAA', '5555555555', True),
                 ),
                 has_entry(
-                    'column_values', contains('Charles', 'CCC', '555123555', True)
+                    'column_values',
+                    contains_exactly('Charles', 'CCC', '555123555', True),
                 ),
             ),
         )
@@ -90,9 +92,12 @@ class TestFavorites(_BaseMultiTokenFavoriteTest):
             result['results'],
             contains_inanyorder(
                 has_entry(
-                    'column_values', contains('Alice', 'AAA', '5555555555', True)
+                    'column_values',
+                    contains_exactly('Alice', 'AAA', '5555555555', True),
                 ),
-                has_entry('column_values', contains('Bob', 'BBB', '5555551234', True)),
+                has_entry(
+                    'column_values', contains_exactly('Bob', 'BBB', '5555551234', True)
+                ),
             ),
         )
 
@@ -104,7 +109,8 @@ class TestFavorites(_BaseMultiTokenFavoriteTest):
                 result['results'],
                 contains_inanyorder(
                     has_entry(
-                        'column_values', contains('Alice', 'AAA', '5555555555', True)
+                        'column_values',
+                        contains_exactly('Alice', 'AAA', '5555555555', True),
                     )
                 ),
             )
@@ -119,7 +125,8 @@ class TestFavorites(_BaseMultiTokenFavoriteTest):
                 result['results'],
                 contains_inanyorder(
                     has_entry(
-                        'column_values', contains('Alice', 'AAA', '5555555555', True)
+                        'column_values',
+                        contains_exactly('Alice', 'AAA', '5555555555', True),
                     )
                 ),
             )
@@ -131,7 +138,8 @@ class TestFavorites(_BaseMultiTokenFavoriteTest):
             result['results'],
             contains_inanyorder(
                 has_entry(
-                    'column_values', contains('Alice', 'AAA', '5555555555', False)
+                    'column_values',
+                    contains_exactly('Alice', 'AAA', '5555555555', False),
                 )
             ),
         )
@@ -142,7 +150,10 @@ class TestFavorites(_BaseMultiTokenFavoriteTest):
         assert_that(
             result['results'],
             contains_inanyorder(
-                has_entry('column_values', contains('Alice', 'AAA', '5555555555', True))
+                has_entry(
+                    'column_values',
+                    contains_exactly('Alice', 'AAA', '5555555555', True),
+                )
             ),
         )
 
@@ -156,9 +167,12 @@ class TestFavorites(_BaseMultiTokenFavoriteTest):
             result['results'],
             contains_inanyorder(
                 has_entry(
-                    'column_values', contains('Alice', 'AAA', '5555555555', True)
+                    'column_values',
+                    contains_exactly('Alice', 'AAA', '5555555555', True),
                 ),
-                has_entry('column_values', contains('Bob', 'BBB', '5555551234', True)),
+                has_entry(
+                    'column_values', contains_exactly('Bob', 'BBB', '5555551234', True)
+                ),
             ),
         )
 
@@ -177,7 +191,8 @@ class TestFavorites(_BaseMultiTokenFavoriteTest):
                 result['results'],
                 contains_inanyorder(
                     has_entry(
-                        'column_values', contains('Alice', 'AAA', '5555555555', True)
+                        'column_values',
+                        contains_exactly('Alice', 'AAA', '5555555555', True),
                     )
                 ),
             )
@@ -202,9 +217,15 @@ class TestFavoritesInPersonalResults(PersonalOnlyTestCase):
             assert_that(
                 result['results'],
                 contains_inanyorder(
-                    has_entry('column_values', contains('Alice', None, None, False)),
-                    has_entry('column_values', contains('Bob', None, None, False)),
-                    has_entry('column_values', contains('Charlie', None, None, False)),
+                    has_entry(
+                        'column_values', contains_exactly('Alice', None, None, False)
+                    ),
+                    has_entry(
+                        'column_values', contains_exactly('Bob', None, None, False)
+                    ),
+                    has_entry(
+                        'column_values', contains_exactly('Charlie', None, None, False)
+                    ),
                 ),
             )
 
@@ -214,9 +235,13 @@ class TestFavoritesInPersonalResults(PersonalOnlyTestCase):
         assert_that(
             personal['results'],
             contains_inanyorder(
-                has_entry('column_values', contains('Alice', None, None, False)),
-                has_entry('column_values', contains('Bob', None, None, True)),
-                has_entry('column_values', contains('Charlie', None, None, False)),
+                has_entry(
+                    'column_values', contains_exactly('Alice', None, None, False)
+                ),
+                has_entry('column_values', contains_exactly('Bob', None, None, True)),
+                has_entry(
+                    'column_values', contains_exactly('Charlie', None, None, False)
+                ),
             ),
         )
 
@@ -227,7 +252,9 @@ class TestFavoritesInPersonalResults(PersonalOnlyTestCase):
 
         assert_that(
             favorites['results'],
-            contains(has_entry('column_values', contains('Alice', None, None, True))),
+            contains_exactly(
+                has_entry('column_values', contains_exactly('Alice', None, None, True))
+            ),
         )
 
     def test_that_removed_favorited_personal_are_not_listed_anymore(self):
@@ -236,7 +263,7 @@ class TestFavoritesInPersonalResults(PersonalOnlyTestCase):
 
         favorites = self.favorites('default')
 
-        assert_that(favorites['results'], contains())
+        assert_that(favorites['results'], contains_exactly())
 
 
 class TestFavoritesBusEvents(PersonalOnlyTestCase):

--- a/integration_tests/suite/test_google.py
+++ b/integration_tests/suite/test_google.py
@@ -1,8 +1,8 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import urllib3
-from hamcrest import assert_that, contains, has_entries, has_item
+from hamcrest import assert_that, contains_exactly, has_entries, has_item
 from wazo_test_helpers.auth import AuthClient as AuthMock
 
 from .helpers.base import BaseDirdIntegrationTest
@@ -289,11 +289,11 @@ class TestGooglePlugin(BaseDirdIntegrationTest):
         assert_that(
             result,
             has_entries(
-                results=contains(
+                results=contains_exactly(
                     has_entries(
                         backend='google',
                         source='google',
-                        column_values=contains(
+                        column_values=contains_exactly(
                             'Mario Bros',
                             'mario@bros.example.com',
                             '5555551234',
@@ -317,7 +317,9 @@ class TestGooglePlugin(BaseDirdIntegrationTest):
         assert_that(
             result,
             has_entries(
-                results=contains(has_entries(column_values=has_item('Luigi Bros')))
+                results=contains_exactly(
+                    has_entries(column_values=has_item('Luigi Bros'))
+                )
             ),
         )
 

--- a/integration_tests/suite/test_google_contacts.py
+++ b/integration_tests/suite/test_google_contacts.py
@@ -1,7 +1,13 @@
 # Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, calling, contains, contains_inanyorder, has_entries
+from hamcrest import (
+    assert_that,
+    calling,
+    contains_exactly,
+    contains_inanyorder,
+    has_entries,
+)
 from wazo_test_helpers.auth import AuthClient as AuthMock
 from wazo_test_helpers.hamcrest.raises import raises
 
@@ -347,22 +353,22 @@ class TestGoogleContactList(BaseGoogleAssetTestCase):
 
         assert_that(
             self.list_(self.client, self.source_uuid, order='name'),
-            has_entries(items=contains(aa, ba, bb)),
+            has_entries(items=contains_exactly(aa, ba, bb)),
         )
 
         assert_that(
             self.list_(self.client, self.source_uuid, order='name', direction='desc'),
-            has_entries(items=contains(bb, ba, aa)),
+            has_entries(items=contains_exactly(bb, ba, aa)),
         )
 
         assert_that(
             self.list_(self.client, self.source_uuid, order='name', limit=1),
-            has_entries(items=contains(aa)),
+            has_entries(items=contains_exactly(aa)),
         )
 
         assert_that(
             self.list_(self.client, self.source_uuid, order='name', offset=1),
-            has_entries(items=contains(ba, bb)),
+            has_entries(items=contains_exactly(ba, bb)),
         )
 
     @fixtures.google_result(GOOGLE_CONTACT_LIST, GOOGLE_SEARCH_LIST)

--- a/integration_tests/suite/test_google_http.py
+++ b/integration_tests/suite/test_google_http.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from contextlib import contextmanager
@@ -8,7 +8,7 @@ import requests
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     equal_to,
     has_entries,
@@ -138,12 +138,13 @@ class TestList(BaseGoogleCRUDTestCase):
         )
 
         assert_that(
-            self.list_(name='abc'), has_entries(items=contains(a), total=3, filtered=1)
+            self.list_(name='abc'),
+            has_entries(items=contains_exactly(a), total=3, filtered=1),
         )
 
         assert_that(
             self.list_(uuid=c['uuid']),
-            has_entries(items=contains(c), total=3, filtered=1),
+            has_entries(items=contains_exactly(c), total=3, filtered=1),
         )
 
         assert_that(
@@ -157,22 +158,22 @@ class TestList(BaseGoogleCRUDTestCase):
     def test_pagination(self, c, b, a):
         assert_that(
             self.list_(order='name'),
-            has_entries(items=contains(a, b, c), total=3, filtered=3),
+            has_entries(items=contains_exactly(a, b, c), total=3, filtered=3),
         )
 
         assert_that(
             self.list_(order='name', direction='desc'),
-            has_entries(items=contains(c, b, a), total=3, filtered=3),
+            has_entries(items=contains_exactly(c, b, a), total=3, filtered=3),
         )
 
         assert_that(
             self.list_(order='name', limit=2),
-            has_entries(items=contains(a, b), total=3, filtered=3),
+            has_entries(items=contains_exactly(a, b), total=3, filtered=3),
         )
 
         assert_that(
             self.list_(order='name', offset=2),
-            has_entries(items=contains(c), total=3, filtered=3),
+            has_entries(items=contains_exactly(c), total=3, filtered=3),
         )
 
     @fixtures.google_source(name='abc', token=VALID_TOKEN_MAIN_TENANT)

--- a/integration_tests/suite/test_graphql.py
+++ b/integration_tests/suite/test_graphql.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from contextlib import contextmanager
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from hamcrest import (
     any_of,
     assert_that,
-    contains,
+    contains_exactly,
     contains_string,
     equal_to,
     has_entries,
@@ -63,7 +63,7 @@ class TestGraphQL(BaseDirdIntegrationTest):
         response = self.dird.graphql.query(query)
         assert_that(
             response['errors'],
-            contains(
+            contains_exactly(
                 has_entries(
                     {
                         'path': ['hello'],
@@ -80,7 +80,7 @@ class TestGraphQL(BaseDirdIntegrationTest):
         response = self.dird.graphql.query(query)
         assert_that(
             response['errors'],
-            contains(
+            contains_exactly(
                 has_entries(
                     {
                         'path': ['hello'],
@@ -183,7 +183,7 @@ class TestGraphQL(BaseDirdIntegrationTest):
 
         assert_that(
             response['data']['me']['contacts']['edges'],
-            contains(
+            contains_exactly(
                 has_entry('node', has_entries({'firstname': 'Alice'})),
                 has_entry('node', has_entries({'firstname': 'Bob'})),
             ),
@@ -210,7 +210,7 @@ class TestGraphQL(BaseDirdIntegrationTest):
 
         assert_that(
             response['data']['user']['contacts']['edges'],
-            contains(
+            contains_exactly(
                 has_entry('node', has_entries({'firstname': 'Alice'})),
                 has_entry('node', has_entries({'firstname': 'Bob'})),
             ),
@@ -237,7 +237,7 @@ class TestGraphQL(BaseDirdIntegrationTest):
 
         assert_that(
             response['errors'],
-            contains(
+            contains_exactly(
                 has_entries(
                     {
                         'path': ['me', 'contacts'],
@@ -269,7 +269,7 @@ class TestGraphQL(BaseDirdIntegrationTest):
 
         assert_that(
             response['errors'],
-            contains(
+            contains_exactly(
                 has_entries(
                     {
                         'path': ['user', 'contacts'],
@@ -301,7 +301,7 @@ class TestGraphQL(BaseDirdIntegrationTest):
 
         assert_that(
             response['data']['me']['contacts']['edges'],
-            contains(
+            contains_exactly(
                 has_entry('node', has_entries({'firstname': 'Alice'})),
                 has_entry('node', None),
                 has_entry('node', has_entries({'firstname': 'Bob'})),
@@ -329,7 +329,7 @@ class TestGraphQL(BaseDirdIntegrationTest):
 
         assert_that(
             response['data']['user']['contacts']['edges'],
-            contains(
+            contains_exactly(
                 has_entry('node', has_entries({'firstname': 'Alice'})),
                 has_entry('node', None),
                 has_entry('node', has_entries({'firstname': 'Bob'})),
@@ -363,7 +363,7 @@ class TestGraphQL(BaseDirdIntegrationTest):
 
         assert_that(
             response['data']['me']['contacts']['edges'],
-            contains(
+            contains_exactly(
                 has_entry(
                     'node',
                     has_entries(
@@ -404,7 +404,7 @@ class TestGraphQL(BaseDirdIntegrationTest):
 
         assert_that(
             response['data']['me']['contacts']['edges'],
-            contains(
+            contains_exactly(
                 has_entry(
                     'node',
                     has_entries(
@@ -423,7 +423,7 @@ class TestGraphQL(BaseDirdIntegrationTest):
             response = dird.graphql.query(query)
             assert_that(
                 response['errors'],
-                contains(
+                contains_exactly(
                     has_entries(
                         {'path': ['hello'], 'message': contains_string('unreachable')}
                     )
@@ -481,7 +481,7 @@ class TestGraphQLWazoBackend(BaseDirdIntegrationTest):
         response = self.dird.graphql.query(query)
         assert_that(
             response['data']['me']['contacts']['edges'],
-            contains(
+            contains_exactly(
                 has_entry(
                     'node',
                     has_entries(

--- a/integration_tests/suite/test_ldap_backend.py
+++ b/integration_tests/suite/test_ldap_backend.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import time
@@ -7,7 +7,7 @@ from collections import namedtuple
 import ldap
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -112,7 +112,7 @@ class TestLDAP(BaseDirdIntegrationTest):
 
         assert_that(
             result['results'][0]['column_values'],
-            contains('Alice', 'Wonderland', '1001'),
+            contains_exactly('Alice', 'Wonderland', '1001'),
         )
 
     def test_lookup_on_telephone_number(self):
@@ -120,7 +120,7 @@ class TestLDAP(BaseDirdIntegrationTest):
 
         assert_that(
             result['results'][0]['column_values'],
-            contains('Alice', 'Wonderland', '1001'),
+            contains_exactly('Alice', 'Wonderland', '1001'),
         )
 
     def test_lookup_with_non_ascii_characters(self):
@@ -128,7 +128,7 @@ class TestLDAP(BaseDirdIntegrationTest):
 
         assert_that(
             result['results'][0]['column_values'],
-            contains('François', 'Hollande', '1004'),
+            contains_exactly('François', 'Hollande', '1004'),
         )
 
     def test_reverse_lookup(self):
@@ -150,8 +150,12 @@ class TestLDAP(BaseDirdIntegrationTest):
         assert_that(
             result['results'],
             contains_inanyorder(
-                has_entry('column_values', contains('Alice', 'Wonderland', '1001')),
-                has_entry('column_values', contains('Connor', 'Manson', '1003')),
+                has_entry(
+                    'column_values', contains_exactly('Alice', 'Wonderland', '1001')
+                ),
+                has_entry(
+                    'column_values', contains_exactly('Connor', 'Manson', '1003')
+                ),
             ),
         )
 
@@ -182,7 +186,8 @@ class TestLDAPWithCustomFilter(BaseDirdIntegrationTest):
         result = self.lookup('charlé', 'default')
 
         assert_that(
-            result['results'][0]['column_values'], contains('Charlé', 'Doe', '1003')
+            result['results'][0]['column_values'],
+            contains_exactly('Charlé', 'Doe', '1003'),
         )
 
     def test_no_result_because_of_the_custom_filter(self):

--- a/integration_tests/suite/test_ldap_http.py
+++ b/integration_tests/suite/test_ldap_http.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from contextlib import contextmanager
@@ -8,7 +8,7 @@ from unittest.mock import ANY
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     equal_to,
     has_entries,
@@ -110,12 +110,12 @@ class TestList(BaseLDAPCRUDTestCase):
 
         assert_that(
             self.client.ldap_source.list(name='abc'),
-            has_entries(items=contains(a), total=3, filtered=1),
+            has_entries(items=contains_exactly(a), total=3, filtered=1),
         )
 
         assert_that(
             self.client.ldap_source.list(uuid=c['uuid']),
-            has_entries(items=contains(c), total=3, filtered=1),
+            has_entries(items=contains_exactly(c), total=3, filtered=1),
         )
 
         result = self.client.ldap_source.list(search='b')
@@ -129,22 +129,22 @@ class TestList(BaseLDAPCRUDTestCase):
     def test_pagination(self, c, b, a):
         assert_that(
             self.client.ldap_source.list(order='name'),
-            has_entries(items=contains(a, b, c), total=3, filtered=3),
+            has_entries(items=contains_exactly(a, b, c), total=3, filtered=3),
         )
 
         assert_that(
             self.client.ldap_source.list(order='name', direction='desc'),
-            has_entries(items=contains(c, b, a), total=3, filtered=3),
+            has_entries(items=contains_exactly(c, b, a), total=3, filtered=3),
         )
 
         assert_that(
             self.client.ldap_source.list(order='name', limit=2),
-            has_entries(items=contains(a, b), total=3, filtered=3),
+            has_entries(items=contains_exactly(a, b), total=3, filtered=3),
         )
 
         assert_that(
             self.client.ldap_source.list(order='name', offset=2),
-            has_entries(items=contains(c), total=3, filtered=3),
+            has_entries(items=contains_exactly(c), total=3, filtered=3),
         )
 
     @fixtures.ldap_source(name='abc', token=VALID_TOKEN_MAIN_TENANT)

--- a/integration_tests/suite/test_office365_backend.py
+++ b/integration_tests/suite/test_office365_backend.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest.mock import Mock
@@ -8,7 +8,7 @@ import urllib3
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     empty,
     equal_to,
     has_entries,
@@ -150,7 +150,7 @@ class TestOffice365Plugin(BaseOffice365PluginTestCase):
 
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     number='5555555555',
                     email='wbros@wazoquebec.onmicrosoft.com',
@@ -167,7 +167,7 @@ class TestOffice365Plugin(BaseOffice365PluginTestCase):
 
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     number='5555555555',
                     email='wbros@wazoquebec.onmicrosoft.com',
@@ -199,7 +199,7 @@ class TestOffice365Plugin(BaseOffice365PluginTestCase):
 
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     number='5555555555',
                     email='wbros@wazoquebec.onmicrosoft.com',
@@ -283,7 +283,11 @@ class TestDirdOffice365Plugin(BaseOffice365TestCase):
         result = self.client.directories.lookup(term='war', profile='default')
         assert_that(
             result,
-            has_entries(results=contains(has_entries(column_values=contains('Wario')))),
+            has_entries(
+                results=contains_exactly(
+                    has_entries(column_values=contains_exactly('Wario'))
+                )
+            ),
         )
 
     @fixtures.office365_result(OFFICE365_CONTACTS)
@@ -310,7 +314,7 @@ class TestDirdOffice365Plugin(BaseOffice365TestCase):
             has_entries(
                 total=1,
                 filtered=1,
-                items=contains(
+                items=contains_exactly(
                     has_entries(
                         displayName='Wario Bros',
                         surname='Bros',

--- a/integration_tests/suite/test_office365_contacts.py
+++ b/integration_tests/suite/test_office365_contacts.py
@@ -4,7 +4,7 @@
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     has_entries,
     has_item,
@@ -240,22 +240,22 @@ class TestOffice365ContactList(BaseOffice365AssetTestCase):
 
         assert_that(
             self.list_(self.client, self.source_uuid, order='name'),
-            has_entries(items=contains(aa, ba, bb)),
+            has_entries(items=contains_exactly(aa, ba, bb)),
         )
 
         assert_that(
             self.list_(self.client, self.source_uuid, order='name', direction='desc'),
-            has_entries(items=contains(bb, ba, aa)),
+            has_entries(items=contains_exactly(bb, ba, aa)),
         )
 
         assert_that(
             self.list_(self.client, self.source_uuid, order='name', limit=1),
-            has_entries(items=contains(aa)),
+            has_entries(items=contains_exactly(aa)),
         )
 
         assert_that(
             self.list_(self.client, self.source_uuid, order='name', offset=1),
-            has_entries(items=contains(ba, bb)),
+            has_entries(items=contains_exactly(ba, bb)),
         )
 
     @fixtures.office365_result(OFFICE365_CONTACT_LIST)

--- a/integration_tests/suite/test_office365_http.py
+++ b/integration_tests/suite/test_office365_http.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from contextlib import contextmanager
@@ -8,7 +8,7 @@ import requests
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     equal_to,
     has_entries,
@@ -147,12 +147,12 @@ class TestList(BaseOffice365CRUDTestCase):
 
         assert_that(
             self.client.backends.list_sources(BACKEND, name='abc'),
-            has_entries(items=contains(a), total=3, filtered=1),
+            has_entries(items=contains_exactly(a), total=3, filtered=1),
         )
 
         assert_that(
             self.client.backends.list_sources(BACKEND, uuid=c['uuid']),
-            has_entries(items=contains(c), total=3, filtered=1),
+            has_entries(items=contains_exactly(c), total=3, filtered=1),
         )
 
         assert_that(
@@ -166,22 +166,22 @@ class TestList(BaseOffice365CRUDTestCase):
     def test_pagination(self, c, b, a):
         assert_that(
             self.client.backends.list_sources(BACKEND, order='name'),
-            has_entries(items=contains(a, b, c), total=3, filtered=3),
+            has_entries(items=contains_exactly(a, b, c), total=3, filtered=3),
         )
 
         assert_that(
             self.client.backends.list_sources(BACKEND, order='name', direction='desc'),
-            has_entries(items=contains(c, b, a), total=3, filtered=3),
+            has_entries(items=contains_exactly(c, b, a), total=3, filtered=3),
         )
 
         assert_that(
             self.client.backends.list_sources(BACKEND, order='name', limit=2),
-            has_entries(items=contains(a, b), total=3, filtered=3),
+            has_entries(items=contains_exactly(a, b), total=3, filtered=3),
         )
 
         assert_that(
             self.client.backends.list_sources(BACKEND, order='name', offset=2),
-            has_entries(items=contains(c), total=3, filtered=3),
+            has_entries(items=contains_exactly(c), total=3, filtered=3),
         )
 
     @fixtures.office365_source(name='abc', token=VALID_TOKEN_MAIN_TENANT)

--- a/integration_tests/suite/test_personal.py
+++ b/integration_tests/suite/test_personal.py
@@ -7,7 +7,7 @@ from unittest.mock import ANY
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -43,7 +43,7 @@ class TestListPersonal(PersonalOnlyTestCase):
     def test_that_listing_empty_personal_returns_empty_list(self):
         result = self.list_personal()
 
-        assert_that(result['items'], contains())
+        assert_that(result['items'], contains_exactly())
 
 
 class TestDeletedUser(BaseDirdIntegrationTest):
@@ -132,7 +132,9 @@ class TestAddPersonal(PersonalOnlyTestCase):
         assert_that(raw['items'], has_items(has_entry('key', 'NonAsciiValue-é')))
         assert_that(
             formatted['results'],
-            has_items(has_entry('column_values', contains('Alice', None, None, False))),
+            has_items(
+                has_entry('column_values', contains_exactly('Alice', None, None, False))
+            ),
         )
 
     def test_that_adding_invalid_personal_returns_400(self):
@@ -231,7 +233,7 @@ class TestPersonalPersistence(PersonalOnlyTestCase):
 
         result_before = self.list_personal()
 
-        assert_that(result_before['items'], contains(has_key('id')))
+        assert_that(result_before['items'], contains_exactly(has_key('id')))
 
         self._run_cmd('docker compose kill dird')
         self._run_cmd('docker compose rm -f dird')
@@ -239,7 +241,7 @@ class TestPersonalPersistence(PersonalOnlyTestCase):
 
         result_after = self.list_personal()
 
-        assert_that(result_after['items'], contains(has_key('id')))
+        assert_that(result_after['items'], contains_exactly(has_key('id')))
         assert_that(
             result_before['items'][0]['id'], equal_to(result_after['items'][0]['id'])
         )
@@ -275,7 +277,9 @@ class TestPersonalVisibility(PersonalOnlyTestCase):
                 has_entry('firstname', 'Alice'), has_entry('firstname', 'Bob')
             ),
         )
-        assert_that(result_2['items'], contains(has_entry('firstname', 'Charlie')))
+        assert_that(
+            result_2['items'], contains_exactly(has_entry('firstname', 'Charlie'))
+        )
 
 
 class TestPersonalListWithProfile(PersonalOnlyTestCase):
@@ -289,7 +293,7 @@ class TestPersonalListWithProfile(PersonalOnlyTestCase):
     def test_that_listing_personal_with_profile_empty_returns_empty_list(self):
         result = self.get_personal_with_profile('default')
 
-        assert_that(result['results'], contains())
+        assert_that(result['results'], contains_exactly())
 
     def test_listing_personal_with_profile(self):
         self.post_personal({'firstname': 'Alice'})
@@ -300,8 +304,10 @@ class TestPersonalListWithProfile(PersonalOnlyTestCase):
         assert_that(
             result['results'],
             contains_inanyorder(
-                has_entry('column_values', contains('Alice', None, None, False)),
-                has_entry('column_values', contains('Bob', None, None, False)),
+                has_entry(
+                    'column_values', contains_exactly('Alice', None, None, False)
+                ),
+                has_entry('column_values', contains_exactly('Bob', None, None, False)),
             ),
         )
 
@@ -353,7 +359,7 @@ class TestLookupPersonal(PersonalOnlyTestCase):
         assert_that(
             result['results'],
             contains_inanyorder(
-                has_entry('column_values', contains('Alice', None, None, False))
+                has_entry('column_values', contains_exactly('Alice', None, None, False))
             ),
         )
 
@@ -363,7 +369,9 @@ class TestLookupPersonal(PersonalOnlyTestCase):
         assert_that(
             result['results'],
             contains_inanyorder(
-                has_entry('column_values', contains('Céline', None, None, False))
+                has_entry(
+                    'column_values', contains_exactly('Céline', None, None, False)
+                )
             ),
         )
 
@@ -373,7 +381,9 @@ class TestLookupPersonal(PersonalOnlyTestCase):
         assert_that(
             result['results'],
             contains_inanyorder(
-                has_entry('column_values', contains('Céline', None, None, False))
+                has_entry(
+                    'column_values', contains_exactly('Céline', None, None, False)
+                )
             ),
         )
 
@@ -383,7 +393,9 @@ class TestLookupPersonal(PersonalOnlyTestCase):
         assert_that(
             result['results'],
             contains_inanyorder(
-                has_entry('column_values', contains('Etienne', None, None, False))
+                has_entry(
+                    'column_values', contains_exactly('Etienne', None, None, False)
+                )
             ),
         )
 
@@ -393,7 +405,9 @@ class TestLookupPersonal(PersonalOnlyTestCase):
         assert_that(
             result['results'],
             contains_inanyorder(
-                has_entry('column_values', contains('john', 'john', None, False))
+                has_entry(
+                    'column_values', contains_exactly('john', 'john', None, False)
+                )
             ),
         )
 
@@ -403,7 +417,9 @@ class TestLookupPersonal(PersonalOnlyTestCase):
         assert_that(
             result['results'],
             contains_inanyorder(
-                has_entry('column_values', contains('empty-column', None, None, False))
+                has_entry(
+                    'column_values', contains_exactly('empty-column', None, None, False)
+                )
             ),
         )
 
@@ -424,7 +440,8 @@ class TestLookupPersonal(PersonalOnlyTestCase):
             result['results'],
             contains_inanyorder(
                 has_entry(
-                    'column_values', contains('William', 'Gates', '222222', False)
+                    'column_values',
+                    contains_exactly('William', 'Gates', '222222', False),
                 )
             ),
         )
@@ -434,7 +451,8 @@ class TestLookupPersonal(PersonalOnlyTestCase):
             not_(
                 contains_inanyorder(
                     has_entry(
-                        'column_values', contains('William', 'Gates', '222222', False)
+                        'column_values',
+                        contains_exactly('William', 'Gates', '222222', False),
                     )
                 )
             ),
@@ -478,7 +496,7 @@ class TestEditPersonal(PersonalOnlyTestCase):
         list_result = self.list_personal()
         assert_that(
             list_result['items'],
-            contains(
+            contains_exactly(
                 all_of(
                     contains_inanyorder('id', 'firstname', 'company'),
                     has_entries({'firstname': 'Nicolas', 'company': 'acme'}),
@@ -578,7 +596,7 @@ class TestSearchPersonal(PersonalOnlyTestCase):
         result = self.list_personal(order='firstname')
         assert_that(
             result['items'],
-            contains(
+            contains_exactly(
                 has_entry('firstname', 'Ãlberto'),
                 has_entry('firstname', 'Alice'),
                 has_entry('firstname', 'bib'),
@@ -591,7 +609,7 @@ class TestSearchPersonal(PersonalOnlyTestCase):
         result = self.list_personal(order='firstname', direction='desc')
         assert_that(
             result['items'],
-            contains(
+            contains_exactly(
                 has_entry('firstname', 'Etienne'),
                 has_entry('firstname', 'Céline'),
                 has_entry('firstname', 'Bob'),
@@ -624,7 +642,7 @@ class TestSearchPersonal(PersonalOnlyTestCase):
         result = self.list_personal(order='firstname', limit=2)
         assert_that(
             result['items'],
-            contains(
+            contains_exactly(
                 has_entry('firstname', 'Ãlberto'),
                 has_entry('firstname', 'Alice'),
             ),

--- a/integration_tests/suite/test_personal_http.py
+++ b/integration_tests/suite/test_personal_http.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from contextlib import contextmanager
@@ -8,7 +8,7 @@ import requests
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     equal_to,
     has_entries,
@@ -106,12 +106,12 @@ class TestList(BasePersonalCRUDTestCase):
 
         assert_that(
             self.client.personal_source.list(name='abc'),
-            has_entries(items=contains(a), total=3, filtered=1),
+            has_entries(items=contains_exactly(a), total=3, filtered=1),
         )
 
         assert_that(
             self.client.personal_source.list(uuid=c['uuid']),
-            has_entries(items=contains(c), total=3, filtered=1),
+            has_entries(items=contains_exactly(c), total=3, filtered=1),
         )
 
         result = self.client.personal_source.list(search='b')
@@ -125,22 +125,22 @@ class TestList(BasePersonalCRUDTestCase):
     def test_pagination(self, c, b, a):
         assert_that(
             self.client.personal_source.list(order='name'),
-            has_entries(items=contains(a, b, c), total=3, filtered=3),
+            has_entries(items=contains_exactly(a, b, c), total=3, filtered=3),
         )
 
         assert_that(
             self.client.personal_source.list(order='name', direction='desc'),
-            has_entries(items=contains(c, b, a), total=3, filtered=3),
+            has_entries(items=contains_exactly(c, b, a), total=3, filtered=3),
         )
 
         assert_that(
             self.client.personal_source.list(order='name', limit=2),
-            has_entries(items=contains(a, b), total=3, filtered=3),
+            has_entries(items=contains_exactly(a, b), total=3, filtered=3),
         )
 
         assert_that(
             self.client.personal_source.list(order='name', offset=2),
-            has_entries(items=contains(c), total=3, filtered=3),
+            has_entries(items=contains_exactly(c), total=3, filtered=3),
         )
 
     @fixtures.personal_source(name='abc', token=VALID_TOKEN_MAIN_TENANT)

--- a/integration_tests/suite/test_personal_import.py
+++ b/integration_tests/suite/test_personal_import.py
@@ -1,11 +1,11 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import textwrap
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     equal_to,
     has_entries,
@@ -89,7 +89,7 @@ class TestPersonalImportSuccess(BaseDirdIntegrationTest):
         )
         result = self.import_personal(csv, VALID_TOKEN_MAIN_TENANT)
 
-        assert_that(result['failed'], contains())
+        assert_that(result['failed'], contains_exactly())
         assert_that(
             result['created'],
             contains_inanyorder(
@@ -118,7 +118,8 @@ class TestPersonalImportSomeFail(BaseDirdIntegrationTest):
         result = self.import_personal(csv, VALID_TOKEN_MAIN_TENANT)
 
         assert_that(
-            result['failed'], contains(has_entry('line', 3), has_entry('line', 5))
+            result['failed'],
+            contains_exactly(has_entry('line', 3), has_entry('line', 5)),
         )
         assert_that(
             self.list_personal()['items'],
@@ -149,7 +150,7 @@ class TestPersonalImportSomeFail(BaseDirdIntegrationTest):
         )
         result = self.import_personal(csv, VALID_TOKEN_MAIN_TENANT)
 
-        assert_that(result['failed'], contains(has_entry('line', 2)))
+        assert_that(result['failed'], contains_exactly(has_entry('line', 2)))
 
 
 class TestPersonalImportUTF8(BaseDirdIntegrationTest):

--- a/integration_tests/suite/test_phonebook.py
+++ b/integration_tests/suite/test_phonebook.py
@@ -6,7 +6,7 @@ from unittest.mock import ANY
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     contains_string,
     empty,
@@ -70,7 +70,7 @@ class TestList(BasePhonebookTestCase):
             assert_that(
                 result.json(),
                 has_entries(
-                    items=contains(
+                    items=contains_exactly(
                         *[has_entries(**phonebook) for phonebook in phonebooks]
                     ),
                     total=3,
@@ -492,7 +492,9 @@ class TestContactList(_BasePhonebookContactTestCase):
             assert_that(
                 result.json(),
                 has_entries(
-                    items=contains(*[has_entries(**contact) for contact in contacts]),
+                    items=contains_exactly(
+                        *[has_entries(**contact) for contact in contacts]
+                    ),
                     total=equal_to(3),
                 ),
             )

--- a/integration_tests/suite/test_phonebook_deprecated.py
+++ b/integration_tests/suite/test_phonebook_deprecated.py
@@ -3,7 +3,13 @@
 
 from unittest.mock import ANY
 
-from hamcrest import assert_that, contains, contains_inanyorder, equal_to, has_entries
+from hamcrest import (
+    assert_that,
+    contains_exactly,
+    contains_inanyorder,
+    equal_to,
+    has_entries,
+)
 
 from .helpers.phonebook_deprecated import BaseDeprecatedPhonebookTestCase
 
@@ -43,7 +49,7 @@ class TestList(BaseDeprecatedPhonebookTestCase):
             assert_that(
                 result.json(),
                 has_entries(
-                    items=contains(
+                    items=contains_exactly(
                         *[has_entries(**phonebook) for phonebook in phonebooks]
                     ),
                     total=3,
@@ -392,7 +398,9 @@ class TestContactList(_BasePhonebookContactTestCase):
             assert_that(
                 result.json(),
                 has_entries(
-                    items=contains(*[has_entries(**contact) for contact in contacts]),
+                    items=contains_exactly(
+                        *[has_entries(**contact) for contact in contacts]
+                    ),
                     total=3,
                 ),
             )

--- a/integration_tests/suite/test_profiles.py
+++ b/integration_tests/suite/test_profiles.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -208,10 +208,10 @@ class TestList(BaseProfileTestCase):
             )
 
             result = self.client.profiles.list(name='abc')
-            self.assert_list_result(result, contains(abc), total=3, filtered=1)
+            self.assert_list_result(result, contains_exactly(abc), total=3, filtered=1)
 
             result = self.client.profiles.list(uuid=cde['uuid'])
-            self.assert_list_result(result, contains(cde), total=3, filtered=1)
+            self.assert_list_result(result, contains_exactly(cde), total=3, filtered=1)
 
             result = self.client.profiles.list(search='b')
             self.assert_list_result(
@@ -231,19 +231,21 @@ class TestList(BaseProfileTestCase):
         ) as bcd, self.profile(self.client, body_cde) as cde:
             result = self.client.profiles.list(order='name')
             self.assert_list_result(
-                result, contains(abc, bcd, cde), total=3, filtered=3
+                result, contains_exactly(abc, bcd, cde), total=3, filtered=3
             )
 
             result = self.client.profiles.list(order='name', direction='desc')
             self.assert_list_result(
-                result, contains(cde, bcd, abc), total=3, filtered=3
+                result, contains_exactly(cde, bcd, abc), total=3, filtered=3
             )
 
             result = self.client.profiles.list(order='name', limit=2)
-            self.assert_list_result(result, contains(abc, bcd), total=3, filtered=3)
+            self.assert_list_result(
+                result, contains_exactly(abc, bcd), total=3, filtered=3
+            )
 
             result = self.client.profiles.list(order='name', offset=2)
-            self.assert_list_result(result, contains(cde), total=3, filtered=3)
+            self.assert_list_result(result, contains_exactly(cde), total=3, filtered=3)
 
     @fixtures.display(token=VALID_TOKEN_MAIN_TENANT)
     @fixtures.display(token=VALID_TOKEN_SUB_TENANT)
@@ -268,7 +270,7 @@ class TestList(BaseProfileTestCase):
             sub_tenant_client, body_sub_profile
         ) as sub:
             result = main_tenant_client.profiles.list()
-            self.assert_list_result(result, contains(main), total=1, filtered=1)
+            self.assert_list_result(result, contains_exactly(main), total=1, filtered=1)
 
             result = main_tenant_client.profiles.list(recurse=True)
             self.assert_list_result(
@@ -395,11 +397,11 @@ class TestPost(BaseProfileTestCase):
                     display=has_entries(uuid=display['uuid']),
                     services=has_entries(
                         lookup=has_entries(
-                            sources=contains(has_entries(uuid=source['uuid'])),
+                            sources=contains_exactly(has_entries(uuid=source['uuid'])),
                             options=has_entries(timeout=5),
                         ),
                         reverse=has_entries(
-                            sources=contains(has_entries(uuid=source['uuid'])),
+                            sources=contains_exactly(has_entries(uuid=source['uuid'])),
                             options=has_entries(timeout=0.5),
                         ),
                     ),
@@ -479,13 +481,13 @@ class TestPut(BaseProfileTestCase):
                     name='updated',
                     services=has_entries(
                         reverse=has_entries(
-                            sources=contains(
+                            sources=contains_exactly(
                                 has_entries(uuid=s1['uuid']),
                                 has_entries(uuid=s2['uuid']),
                             )
                         ),
                         favorites=has_entries(
-                            sources=contains(has_entries(uuid=s2['uuid']))
+                            sources=contains_exactly(has_entries(uuid=s2['uuid']))
                         ),
                     ),
                 ),
@@ -573,7 +575,9 @@ class TestPut(BaseProfileTestCase):
                     name='profile',
                     services=has_entries(
                         lookup=has_entries(
-                            sources=contains(has_entries(uuid=sub_source['uuid']))
+                            sources=contains_exactly(
+                                has_entries(uuid=sub_source['uuid'])
+                            )
                         )
                     ),
                 ),
@@ -656,7 +660,7 @@ class TestGetSourcesFromProfile(BaseProfileTestCase):
 
         assert_that(
             response['items'],
-            contains(
+            contains_exactly(
                 has_entries(name='a_wazo_main'),
                 has_entries(name='csv_main'),
                 has_entries(name='personal_main'),
@@ -670,7 +674,7 @@ class TestGetSourcesFromProfile(BaseProfileTestCase):
 
         assert_that(
             response['items'],
-            contains(
+            contains_exactly(
                 has_entries(name='personal_main', backend='personal'),
                 has_entries(name='csv_main', backend='csv'),
                 has_entries(name='a_wazo_main', backend='wazo'),
@@ -696,7 +700,7 @@ class TestGetSourcesFromProfile(BaseProfileTestCase):
 
         assert_that(
             response['items'],
-            contains(
+            contains_exactly(
                 has_entries(name='a_wazo_main', backend='wazo'),
                 has_entries(name='csv_main', backend='csv'),
                 has_entries(name='personal_main', backend='personal'),
@@ -710,7 +714,7 @@ class TestGetSourcesFromProfile(BaseProfileTestCase):
 
         assert_that(
             response['items'],
-            contains(
+            contains_exactly(
                 has_entries(name='csv_main', backend='csv'),
                 has_entries(name='personal_main', backend='personal'),
                 has_entries(name='a_wazo_main', backend='wazo'),
@@ -764,7 +768,8 @@ class TestGetSourcesFromProfile(BaseProfileTestCase):
         response = self.client.directories.list_sources('main', **list_params)
 
         assert_that(
-            response['items'], contains(has_entries(name='a_wazo_main', backend='wazo'))
+            response['items'],
+            contains_exactly(has_entries(name='a_wazo_main', backend='wazo')),
         )
 
     def test_given_over_limit_when_get_then_sources_returned(self):
@@ -774,7 +779,7 @@ class TestGetSourcesFromProfile(BaseProfileTestCase):
 
         assert_that(
             response['items'],
-            contains(
+            contains_exactly(
                 has_entries(name='a_wazo_main', backend='wazo'),
                 has_entries(name='csv_main', backend='csv'),
                 has_entries(name='personal_main', backend='personal'),
@@ -788,7 +793,7 @@ class TestGetSourcesFromProfile(BaseProfileTestCase):
 
         assert_that(
             response['items'],
-            contains(has_entries(name='personal_main', backend='personal')),
+            contains_exactly(has_entries(name='personal_main', backend='personal')),
         )
 
     def test_given_oversized_offset_when_get_then_no_sources_returned(self):
@@ -805,7 +810,9 @@ class TestGetSourcesFromProfile(BaseProfileTestCase):
         assert_that(
             response,
             has_entries(
-                items=contains(has_entries(name='personal_main', backend='personal')),
+                items=contains_exactly(
+                    has_entries(name='personal_main', backend='personal')
+                ),
                 total=3,
                 filtered=3,
             ),
@@ -818,7 +825,9 @@ class TestGetSourcesFromProfile(BaseProfileTestCase):
             has_entries(
                 total=3,
                 filtered=1,
-                items=contains(has_entries(name='personal_main', backend='personal')),
+                items=contains_exactly(
+                    has_entries(name='personal_main', backend='personal')
+                ),
             ),
         )
 
@@ -828,7 +837,7 @@ class TestGetSourcesFromProfile(BaseProfileTestCase):
             has_entries(
                 total=3,
                 filtered=1,
-                items=contains(has_entries(name='csv_main', backend='csv')),
+                items=contains_exactly(has_entries(name='csv_main', backend='csv')),
             ),
         )
 
@@ -838,7 +847,7 @@ class TestGetSourcesFromProfile(BaseProfileTestCase):
             has_entries(
                 total=3,
                 filtered=2,
-                items=contains(
+                items=contains_exactly(
                     has_entries(name='csv_main', backend='csv'),
                     has_entries(name='personal_main', backend='personal'),
                 ),

--- a/integration_tests/suite/test_reverse_timeout.py
+++ b/integration_tests/suite/test_reverse_timeout.py
@@ -3,7 +3,7 @@
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_string,
     equal_to,
     has_entries,
@@ -132,7 +132,7 @@ class TestReverseServiceTimeout(BaseDirdIntegrationTest):
 
         assert_that(
             response['data']['me']['contacts']['edges'],
-            contains(
+            contains_exactly(
                 has_entry('node', has_entries({'firstname': 'Bob'})),
                 has_entry('node', none()),
             ),

--- a/integration_tests/suite/test_sources.py
+++ b/integration_tests/suite/test_sources.py
@@ -1,7 +1,13 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, calling, contains, contains_inanyorder, has_properties
+from hamcrest import (
+    assert_that,
+    calling,
+    contains_exactly,
+    contains_inanyorder,
+    has_properties,
+)
 from wazo_test_helpers.hamcrest.raises import raises
 
 from .helpers.base import BaseDirdIntegrationTest
@@ -35,18 +41,24 @@ class TestList(BaseDirdIntegrationTest):
 
         result = self.client.sources.list(name='abc')
         self.assert_list_result(
-            result, contains(self._source_to_dict('ldap', **abc)), total=3, filtered=1
+            result,
+            contains_exactly(self._source_to_dict('ldap', **abc)),
+            total=3,
+            filtered=1,
         )
 
         result = self.client.sources.list(backend='csv')
         self.assert_list_result(
-            result, contains(self._source_to_dict('csv', **cde)), total=3, filtered=1
+            result,
+            contains_exactly(self._source_to_dict('csv', **cde)),
+            total=3,
+            filtered=1,
         )
 
         result = self.client.sources.list(uuid=bcd['uuid'])
         self.assert_list_result(
             result,
-            contains(self._source_to_dict('personal', **bcd)),
+            contains_exactly(self._source_to_dict('personal', **bcd)),
             total=3,
             filtered=1,
         )
@@ -70,13 +82,16 @@ class TestList(BaseDirdIntegrationTest):
 
         result = main_tenant_client.sources.list()
         self.assert_list_result(
-            result, contains(self._source_to_dict('ldap', **abc)), total=1, filtered=1
+            result,
+            contains_exactly(self._source_to_dict('ldap', **abc)),
+            total=1,
+            filtered=1,
         )
 
         result = main_tenant_client.sources.list(recurse=True)
         self.assert_list_result(
             result,
-            contains(
+            contains_exactly(
                 self._source_to_dict('ldap', **abc),
                 self._source_to_dict('personal', **bcd),
             ),
@@ -87,7 +102,7 @@ class TestList(BaseDirdIntegrationTest):
         result = main_tenant_client.sources.list(tenant_uuid=SUB_TENANT, recurse=True)
         self.assert_list_result(
             result,
-            contains(self._source_to_dict('personal', **bcd)),
+            contains_exactly(self._source_to_dict('personal', **bcd)),
             total=1,
             filtered=1,
         )
@@ -95,7 +110,7 @@ class TestList(BaseDirdIntegrationTest):
         result = sub_tenant_client.sources.list()
         self.assert_list_result(
             result,
-            contains(self._source_to_dict('personal', **bcd)),
+            contains_exactly(self._source_to_dict('personal', **bcd)),
             total=1,
             filtered=1,
         )
@@ -103,7 +118,7 @@ class TestList(BaseDirdIntegrationTest):
         result = sub_tenant_client.sources.list(recurse=True)
         self.assert_list_result(
             result,
-            contains(self._source_to_dict('personal', **bcd)),
+            contains_exactly(self._source_to_dict('personal', **bcd)),
             total=1,
             filtered=1,
         )
@@ -124,7 +139,7 @@ class TestList(BaseDirdIntegrationTest):
         result = self.client.sources.list(order='name')
         self.assert_list_result(
             result,
-            contains(
+            contains_exactly(
                 self._source_to_dict('ldap', **abc),
                 self._source_to_dict('personal', **bcd),
                 self._source_to_dict('csv', **cde),
@@ -136,7 +151,7 @@ class TestList(BaseDirdIntegrationTest):
         result = self.client.sources.list(order='backend')
         self.assert_list_result(
             result,
-            contains(
+            contains_exactly(
                 self._source_to_dict('csv', **cde),
                 self._source_to_dict('ldap', **abc),
                 self._source_to_dict('personal', **bcd),
@@ -148,7 +163,7 @@ class TestList(BaseDirdIntegrationTest):
         result = self.client.sources.list(order='name', direction='desc')
         self.assert_list_result(
             result,
-            contains(
+            contains_exactly(
                 self._source_to_dict('csv', **cde),
                 self._source_to_dict('personal', **bcd),
                 self._source_to_dict('ldap', **abc),
@@ -160,7 +175,7 @@ class TestList(BaseDirdIntegrationTest):
         result = self.client.sources.list(order='name', limit=2)
         self.assert_list_result(
             result,
-            contains(
+            contains_exactly(
                 self._source_to_dict('ldap', **abc),
                 self._source_to_dict('personal', **bcd),
             ),
@@ -170,7 +185,10 @@ class TestList(BaseDirdIntegrationTest):
 
         result = self.client.sources.list(order='name', offset=2)
         self.assert_list_result(
-            result, contains(self._source_to_dict('csv', **cde)), total=3, filtered=3
+            result,
+            contains_exactly(self._source_to_dict('csv', **cde)),
+            total=3,
+            filtered=3,
         )
 
     @staticmethod

--- a/integration_tests/suite/test_wazo_user_backend.py
+++ b/integration_tests/suite/test_wazo_user_backend.py
@@ -1,11 +1,11 @@
-# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest.mock import Mock
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -87,7 +87,7 @@ class TestWazoUser(DirdAssetRunningTestCase):
         for term in search_terms:
             results = self.backend.search(term)
 
-            assert_that(results, contains(has_entries(**self._dylan)))
+            assert_that(results, contains_exactly(has_entries(**self._dylan)))
 
         search_terms = [
             'pic',
@@ -100,7 +100,7 @@ class TestWazoUser(DirdAssetRunningTestCase):
         for term in search_terms:
             results = self.backend.search(term)
 
-            assert_that(results, contains(has_entries(**self._picasso)))
+            assert_that(results, contains_exactly(has_entries(**self._picasso)))
 
     def test_that_the_reverse_lookup_returns_the_expected_result(self):
         result = self.backend.first('1000')
@@ -148,7 +148,7 @@ class TestWazoUserNoConfd(BaseDirdIntegrationTest):
 
     def test_given_no_confd_when_lookup_then_returns_no_results(self):
         result = self.lookup('dyl', 'default')
-        assert_that(result['results'], contains())
+        assert_that(result['results'], contains_exactly())
 
 
 class TestWazoUserLateConfd(BaseDirdIntegrationTest):
@@ -158,7 +158,7 @@ class TestWazoUserLateConfd(BaseDirdIntegrationTest):
     def test_no_result_until_started(self):
         # dird is not stuck on a late confd
         result = self.lookup('dyl', 'default')
-        assert_that(result['results'], contains())
+        assert_that(result['results'], contains_exactly())
 
         self.docker_exec(['touch', '/var/local/start-confd'], service_name='america')
 
@@ -166,8 +166,10 @@ class TestWazoUserLateConfd(BaseDirdIntegrationTest):
             result = self.lookup('dyl', 'default')
             assert_that(
                 result['results'],
-                contains(
-                    has_entry('column_values', contains('Bob', 'Dylan', '1000', ''))
+                contains_exactly(
+                    has_entry(
+                        'column_values', contains_exactly('Bob', 'Dylan', '1000', '')
+                    )
                 ),
             )
 
@@ -235,10 +237,12 @@ class TestWazoUserMultipleWazo(BaseDirdIntegrationTest):
             result['results'],
             contains_inanyorder(
                 has_entries(
-                    source='wazo_asia', column_values=contains('Alice', None, '6543')
+                    source='wazo_asia',
+                    column_values=contains_exactly('Alice', None, '6543'),
                 ),
                 has_entries(
-                    source='wazo_america', column_values=contains('John', 'Doe', '1234')
+                    source='wazo_america',
+                    column_values=contains_exactly('John', 'Doe', '1234'),
                 ),
             ),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ profile = "black"
 py_version = 311
 
 [tool.pytest.ini_options]
+# also used by integration tests, except testpaths since they pass explicit paths
 testpaths = ["wazo_dird"]
 filterwarnings = [
     # test doubles use self-signed certs; verification is intentionally disabled

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,10 @@ py_version = 311
 
 [tool.pytest.ini_options]
 testpaths = ["wazo_dird"]
+filterwarnings = [
+    # test doubles use self-signed certs; verification is intentionally disabled
+    "ignore::urllib3.exceptions.InsecureRequestWarning",
+]
 
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
- **test: suppress urllib3 InsecureRequestWarning**
- **test: replace deprecated hamcrest contains with contains_exactly**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion and warning-filter changes; no production or API behavior is modified.
> 
> **Overview**
> Cleans up **test noise** without changing runtime behavior: integration suite assertions now use Hamcrest **`contains_exactly`** instead of deprecated **`contains`**, and **`pyproject.toml`** ignores **`urllib3.exceptions.InsecureRequestWarning`** where tests deliberately disable TLS verification.
> 
> **Hamcrest:** Across the integration test suite (backends, CSV/conference/Google/Office365/LDAP, personal, phonebook, profiles, GraphQL, etc.), ordered sequence checks and nested `column_values` / `items` matchers are switched to **`contains_exactly`**. **`contains_inanyorder`** is unchanged where order is not fixed. Empty-result cases use **`contains_exactly()`** instead of **`contains()`**.
> 
> **Pytest:** **`filterwarnings`** documents that self-signed certs in test doubles are intentional, so CI logs stay quiet.
> 
> Several integration files only update copyright years to 2026.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bbe5fb6cb83e42da35dd29b4088e08cb2969aa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->