### PR TITLE
reuse-request-token

### DIFF
--- a/wazo_dird/auth.py
+++ b/wazo_dird/auth.py
@@ -8,7 +8,9 @@ from typing import Any, TypeVar, cast
 from wazo_auth_client import Client
 from werkzeug.local import LocalProxy as Proxy
 from xivo.auth_verifier import no_auth, required_acl, required_tenant
+from xivo.rest_api_helpers import APIException
 from xivo.status import Status, StatusDict
+from xivo.tenant_flask_helpers import user
 
 from .config import AuthConfig
 from .exception import MasterTenantNotInitiatedException
@@ -30,6 +32,15 @@ def client() -> Client:
     if not auth_client:
         auth_client = Client(**cast('AuthConfig', auth_config))
     return auth_client
+
+
+def get_user_uuid() -> str:
+    # reads the request-scoped token: no wazo-auth request once it is loaded
+    user_uuid = user.uuid
+    if not user_uuid:
+        raise APIException(401, 'This token has no user UUID', 'invalid-token')
+
+    return user_uuid
 
 
 F = TypeVar('F', bound=Callable[..., Any])

--- a/wazo_dird/plugins/default_json/http.py
+++ b/wazo_dird/plugins/default_json/http.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -12,8 +12,7 @@ from flask_restful import reqparse
 from requests.exceptions import HTTPError
 from xivo.tenant_flask_helpers import Tenant
 
-from wazo_dird import auth
-from wazo_dird.auth import required_acl
+from wazo_dird.auth import get_user_uuid, required_acl
 from wazo_dird.exception import (
     NoSuchProfile,
     NoSuchProfileAPIException,
@@ -83,8 +82,7 @@ class Lookup(LegacyAuthResource, DisplayAwareResource):
             return e.body, e.status_code
 
         token = request.headers['X-Auth-Token']
-        token_infos = auth.client().token.get(token)
-        user_uuid = token_infos['metadata']['uuid']
+        user_uuid = get_user_uuid()
 
         raw_results = self.lookup_service.lookup(
             cast(ProfileConfig, profile_config),
@@ -232,12 +230,11 @@ class FavoritesRead(LegacyAuthResource, DisplayAwareResource):
             return e.body, e.status_code
 
         token = request.headers.get('X-Auth-Token', '')
-        token_infos = auth.client().token.get(token)
 
         try:
             raw_results = self.favorites_service.favorites(
                 cast(ProfileConfig, profile_config),
-                token_infos['metadata']['uuid'],
+                get_user_uuid(),
                 token,
             )
         except self.favorites_service.NoSuchProfileException as e:
@@ -255,13 +252,10 @@ class FavoritesWrite(LegacyAuthResource):
     def put(
         self, directory: str, contact: str
     ) -> tuple[str, int] | tuple[dict[str, Any], int]:
-        token = request.headers.get('X-Auth-Token', '')
-        token_infos = auth.client().token.get(token)
-
         tenant = Tenant.autodetect()
         try:
             self.favorites_service.new_favorite(
-                tenant.uuid, directory, contact, token_infos['metadata']['uuid']
+                tenant.uuid, directory, contact, get_user_uuid()
             )
         except self.favorites_service.DuplicatedFavoriteException:
             return _error(409, 'Adding this favorite would create a duplicate')
@@ -273,13 +267,10 @@ class FavoritesWrite(LegacyAuthResource):
     def delete(
         self, directory: str, contact: str
     ) -> tuple[str, int] | tuple[dict[str, Any], int]:
-        token = request.headers.get('X-Auth-Token', '')
-        token_infos = auth.client().token.get(token)
-
         tenant = Tenant.autodetect()
         try:
             self.favorites_service.remove_favorite(
-                tenant.uuid, directory, contact, token_infos['metadata']['uuid']
+                tenant.uuid, directory, contact, get_user_uuid()
             )
             return '', 204
         except (
@@ -309,9 +300,6 @@ class Personal(LegacyAuthResource, DisplayAwareResource):
     @required_acl('dird.directories.personal.{profile}.read')
     def get(self, profile: str) -> dict[str, Any] | tuple[dict[str, Any], int]:
         logger.debug('Listing personal with profile %s', profile)
-        token = request.headers.get('X-Auth-Token', '')
-        token_infos = auth.client().token.get(token)
-
         tenant = Tenant.autodetect()
         try:
             profile_config = self.profile_service.get_by_name(tenant.uuid, profile)
@@ -319,13 +307,12 @@ class Personal(LegacyAuthResource, DisplayAwareResource):
         except OldAPIException as e:
             return e.body, e.status_code
 
-        raw_results = self.personal_service.list_contacts(
-            tenant.uuid, token_infos['metadata']['uuid']
-        )
+        user_uuid = get_user_uuid()
+        raw_results = self.personal_service.list_contacts(tenant.uuid, user_uuid)
 
         try:
             favorites = self.favorite_service.favorite_ids(
-                cast(ProfileConfig, profile_config), token_infos['metadata']['uuid']
+                cast(ProfileConfig, profile_config), user_uuid
             ).by_name
         except self.favorite_service.NoSuchProfileException as e:
             return _error(404, str(e))

--- a/wazo_dird/plugins/graphql/plugin.py
+++ b/wazo_dird/plugins/graphql/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -12,7 +12,7 @@ from wazo_auth_client.exceptions import MissingPermissionsTokenException
 from xivo.auth_verifier import AuthServerUnreachable, Unauthorized
 from xivo.flask.headers import extract_token_id_from_header
 from xivo.rest_api_helpers import APIException
-from xivo.tenant_helpers import Tenant
+from xivo.tenant_flask_helpers import Tenant
 
 from wazo_dird import BaseViewPlugin, http_server
 
@@ -44,7 +44,7 @@ class AuthorizationMiddleware:
         root_field = info.field_name
         required_acl = f'dird.graphql.{root_field}'
         try:
-            tenant = Tenant.autodetect(self._auth_client)
+            tenant = Tenant.autodetect()
         except AuthServerUnreachable as e:
             host = self._auth_config['host']
             port = self._auth_config['port']

--- a/wazo_dird/plugins/graphql/resolver.py
+++ b/wazo_dird/plugins/graphql/resolver.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -6,8 +6,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 from graphql import Undefined
+from xivo.tenant_flask_helpers import user
 
-from wazo_dird import auth
 from wazo_dird.exception import NoSuchProfile, NoSuchProfileAPIException
 
 from . import schema
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     class ContextDict(TypedDict):
         resolver: Resolver
         token_id: str
-        user_uuid: str
+        user_uuid: str | None
         tenant_uuid: str
 
     class ResolveInfo(GraphQLResolveInfo):
@@ -48,14 +48,12 @@ class Resolver:
     def get_user_me(
         self, root: _SourceResult, info: ResolveInfo, **args: Any
     ) -> dict[str, Any]:
-        token_info = auth.client().token.get(info.context['token_id'])
-        metadata = token_info['metadata']
-        info.context['user_uuid'] = metadata['uuid']
+        info.context['user_uuid'] = user.uuid
         return {}
 
     def get_user_me_uuid(
         self, root: _SourceResult, info: ResolveInfo, **args: Any
-    ) -> str:
+    ) -> str | None:
         return info.context['user_uuid']
 
     def get_user_by_uuid(

--- a/wazo_dird/plugins/graphql/schema.py
+++ b/wazo_dird/plugins/graphql/schema.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -112,7 +112,9 @@ class UserMe(ObjectType):
     ) -> list[Any]:
         return info.context['resolver'].get_user_contacts(parent, info, **args)
 
-    def resolve_user_uuid(parent: _SourceResult, info: ResolveInfo, **args: Any) -> str:
+    def resolve_user_uuid(
+        parent: _SourceResult, info: ResolveInfo, **args: Any
+    ) -> str | None:
         return info.context['resolver'].get_user_me_uuid(parent, info, **args)
 
 
@@ -134,7 +136,9 @@ class User(ObjectType):
     ) -> list[Any]:
         return info.context['resolver'].get_user_contacts(parent, info, **args)
 
-    def resolve_uuid(parent: _SourceResult, info: ResolveInfo, **args: Any) -> str:
+    def resolve_uuid(
+        parent: _SourceResult, info: ResolveInfo, **args: Any
+    ) -> str | None:
         return info.context['resolver'].get_user_me_uuid(parent, info, **args)
 
 

--- a/wazo_dird/plugins/personal/http.py
+++ b/wazo_dird/plugins/personal/http.py
@@ -9,15 +9,13 @@ import logging
 import re
 from collections.abc import Callable
 from time import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from flask import Response, request
 from flask_restful import reqparse
-from xivo.rest_api_helpers import APIException
 from xivo.tenant_flask_helpers import Tenant
 
-from wazo_dird import auth
-from wazo_dird.auth import required_acl
+from wazo_dird.auth import get_user_uuid, required_acl
 from wazo_dird.http import LegacyAuthResource, get_json_body
 
 if TYPE_CHECKING:
@@ -33,16 +31,6 @@ parser = reqparse.RequestParser()
 parser.add_argument('format', type=str, required=False, location='args')
 
 
-def _get_calling_user_uuid() -> str:
-    token = request.headers['X-Auth-Token']
-    token_infos = auth.client().token.get(token)
-    user_uuid = token_infos.get('metadata').get('uuid')
-    if not user_uuid:
-        raise APIException(401, 'This token has no user UUID', 'invalid-token')
-
-    return cast(str, user_uuid)
-
-
 class PersonalAll(LegacyAuthResource):
     personal_service: _PersonalService
 
@@ -52,7 +40,7 @@ class PersonalAll(LegacyAuthResource):
 
     @required_acl('dird.personal.create')
     def post(self) -> tuple[dict[str, Any] | None, int]:
-        user_uuid = _get_calling_user_uuid()
+        user_uuid = get_user_uuid()
         tenant_uuid = Tenant.autodetect().uuid
         contact = get_json_body()
         try:
@@ -75,7 +63,7 @@ class PersonalAll(LegacyAuthResource):
     def get(
         self,
     ) -> tuple[dict[str, Any], int] | tuple[str, int] | Response:
-        user_uuid = _get_calling_user_uuid()
+        user_uuid = get_user_uuid()
         try:
             contacts = self.personal_service.list_contacts_raw(
                 user_uuid, search_params=request.args
@@ -93,7 +81,7 @@ class PersonalAll(LegacyAuthResource):
 
     @required_acl('dird.personal.delete')
     def delete(self) -> tuple[str, int]:
-        user_uuid = _get_calling_user_uuid()
+        user_uuid = get_user_uuid()
 
         self.personal_service.purge_contacts(user_uuid)
 
@@ -158,7 +146,7 @@ class PersonalOne(LegacyAuthResource):
     def get(
         self, contact_id: str
     ) -> tuple[ContactInfo, int] | tuple[dict[str, Any], int]:
-        user_uuid = _get_calling_user_uuid()
+        user_uuid = get_user_uuid()
         try:
             contact = self.personal_service.get_contact(contact_id, user_uuid)
             return contact, 200
@@ -168,7 +156,7 @@ class PersonalOne(LegacyAuthResource):
 
     @required_acl('dird.personal.{contact_id}.update')
     def put(self, contact_id: str) -> tuple[dict[str, Any] | None, int]:
-        user_uuid = _get_calling_user_uuid()
+        user_uuid = get_user_uuid()
         tenant_uuid = Tenant.autodetect().uuid
         new_contact = get_json_body()
         try:
@@ -192,7 +180,7 @@ class PersonalOne(LegacyAuthResource):
 
     @required_acl('dird.personal.{contact_id}.delete')
     def delete(self, contact_id: str) -> tuple[str | dict[str, Any], int]:
-        user_uuid = _get_calling_user_uuid()
+        user_uuid = get_user_uuid()
         try:
             self.personal_service.remove_contact(contact_id, user_uuid)
             return '', 204
@@ -210,7 +198,7 @@ class PersonalImport(LegacyAuthResource):
 
     @required_acl('dird.personal.import.create')
     def post(self) -> tuple[dict[str, Any], int]:
-        user_uuid = _get_calling_user_uuid()
+        user_uuid = get_user_uuid()
         tenant_uuid = Tenant.autodetect().uuid
 
         charset = request.mimetype_params.get('charset', 'utf-8')


### PR DESCRIPTION
Why: lookup, favorites, personal and graphql requests fetched the token
from wazo-auth a second time only to read the user UUID, while xivo's
request-scoped token proxy already held it. Measured against the
integration stack, lookup, favorites and graphql go from 3 wazo-auth
requests down to 2; reverse, lookup by UUID and /personal were already
minimal and are unchanged.

The graphql middleware now autodetects the tenant through the Flask
helper. That is what makes the saving possible there: the token it loads
becomes request-scoped, so the resolvers reuse it instead of fetching
their own copy.

Endpoints that need a user UUID now answer 401 instead of 500 when the
token has none, and the graphql uuid fields are typed nullable to match
the schema they expose.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth identity resolution across REST and GraphQL; behavior change for tokens without a user UUID (401 vs 500) and reliance on request-scoped token population after `Tenant.autodetect()`.
> 
> **Overview**
> **Stops redundant wazo-auth `token.get` calls** by reading the caller’s user UUID from xivo’s request-scoped `user` proxy via new shared **`get_user_uuid()`** in `auth.py`. Lookup, favorites, directory personal, and `/personal` HTTP handlers use that helper instead of fetching the token again after ACL/tenant checks.
> 
> **GraphQL** switches **`Tenant.autodetect()`** to the Flask helper (no auth client argument) so tenant detection shares the same request-scoped token; resolvers set **`user_uuid`** from **`user.uuid`** instead of another **`token.get`**.
> 
> **Error and schema alignment:** missing user UUID on a token now returns **401** (`invalid-token`) rather than failing with 500. GraphQL **`user_uuid`** / **`uuid`** resolvers are typed **`str | None`** to match nullable fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 849423c9f6c005383f2658cce4e00c1a70a3664a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->