### PR TITLE
TASK-511-reuse-request-token

### DIFF
--- a/integration_tests/suite/test_auth_requests.py
+++ b/integration_tests/suite/test_auth_requests.py
@@ -1,0 +1,136 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from hamcrest import assert_that, equal_to, has_key, has_length, not_
+from wazo_test_helpers.auth import AuthClient as MockAuthClient
+from wazo_test_helpers.auth import MockUserToken
+
+from .helpers.base import BaseDirdIntegrationTest
+from .helpers.config import new_csv_with_multiple_displays_config
+from .helpers.constants import MAIN_TENANT
+
+USER_UUID = 'my-user-uuid'
+
+
+class TestTokenRequestCount(BaseDirdIntegrationTest):
+    '''wazo-dird must not fetch the same token from wazo-auth twice.
+
+    The counts below are a budget: verify_token always costs one request,
+    and the token itself is fetched at most once more, only when the user
+    UUID or the tenant cannot be read from the request headers.
+    '''
+
+    asset = 'all_routes'
+    config_factory = new_csv_with_multiple_displays_config
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.auth = MockAuthClient('127.0.0.1', cls.service_port(9497, 'auth'))
+        token = MockUserToken.some_token(
+            metadata={'uuid': USER_UUID, 'tenant_uuid': MAIN_TENANT}
+        )
+        cls.auth.set_token(token)
+        cls.token = token.token_id
+
+    def _count_token_requests(self, url, tenant=None, **kwargs):
+        with self.auth.capture_requests() as capture:
+            response = self.get(url, token=self.token, tenant=tenant, **kwargs)
+        assert_that(response.status_code, equal_to(200))
+        return [
+            request
+            for request in capture.requests
+            if request['path'].startswith('/0.1/token')
+            and request['method'] in ('GET', 'HEAD')
+        ]
+
+    def _count_graphql_token_requests(self, query, tenant=None):
+        with self.auth.capture_requests() as capture:
+            response = self.post(
+                self.url('graphql'),
+                json={'query': query},
+                token=self.token,
+                tenant=tenant,
+            )
+        assert_that(response.status_code, equal_to(200))
+        assert_that(response.json(), not_(has_key('errors')))
+        return [
+            request
+            for request in capture.requests
+            if request['path'].startswith('/0.1/token')
+            and request['method'] in ('GET', 'HEAD')
+        ]
+
+    def test_lookup(self):
+        url = self.url('directories', 'lookup', 'default')
+        params = {'term': 'alice'}
+
+        requests = self._count_token_requests(url, params=params)
+        assert_that(requests, has_length(2), 'the tenant comes from the token')
+
+        requests = self._count_token_requests(url, tenant=MAIN_TENANT, params=params)
+        assert_that(requests, has_length(2), 'the user UUID comes from the token')
+
+    def test_lookup_by_user_uuid(self):
+        url = self.url('directories', 'lookup', 'default', USER_UUID)
+        params = {'term': 'alice'}
+
+        requests = self._count_token_requests(url, params=params)
+        assert_that(requests, has_length(2), 'the tenant comes from the token')
+
+        requests = self._count_token_requests(url, tenant=MAIN_TENANT, params=params)
+        assert_that(requests, has_length(1), 'nothing is read from the token')
+
+    def test_reverse(self):
+        url = self.url('directories', 'reverse', 'default', USER_UUID)
+        params = {'exten': '1234'}
+
+        requests = self._count_token_requests(url, params=params)
+        assert_that(requests, has_length(2), 'the tenant comes from the token')
+
+        requests = self._count_token_requests(url, tenant=MAIN_TENANT, params=params)
+        assert_that(requests, has_length(1), 'nothing is read from the token')
+
+    def test_favorites(self):
+        url = self.url('directories', 'favorites', 'default')
+
+        requests = self._count_token_requests(url)
+        assert_that(requests, has_length(2), 'the tenant comes from the token')
+
+        requests = self._count_token_requests(url, tenant=MAIN_TENANT)
+        assert_that(requests, has_length(2), 'the user UUID comes from the token')
+
+    def test_personal(self):
+        url = self.url('personal')
+
+        requests = self._count_token_requests(url)
+        assert_that(requests, has_length(2), 'the user UUID comes from the token')
+
+        requests = self._count_token_requests(url, tenant=MAIN_TENANT)
+        assert_that(requests, has_length(2), 'the user UUID comes from the token')
+
+    def test_graphql_user_me(self):
+        query = '{ me { userUuid } }'
+
+        requests = self._count_graphql_token_requests(query)
+        assert_that(requests, has_length(2), 'the tenant comes from the token')
+
+        requests = self._count_graphql_token_requests(query, tenant=MAIN_TENANT)
+        assert_that(requests, has_length(3), 'the tenant is checked against the token')
+
+    def test_graphql_user_me_contacts(self):
+        query = '''
+        {
+            me {
+                contacts(profile: "default", extens: ["1234"]) {
+                    edges { node { firstname } }
+                }
+            }
+        }
+        '''
+
+        requests = self._count_graphql_token_requests(query)
+        assert_that(requests, has_length(2), 'the tenant comes from the token')
+
+        requests = self._count_graphql_token_requests(query, tenant=MAIN_TENANT)
+        assert_that(requests, has_length(3), 'the tenant is checked against the token')

--- a/wazo_dird/auth.py
+++ b/wazo_dird/auth.py
@@ -8,7 +8,9 @@ from typing import Any, TypeVar, cast
 from wazo_auth_client import Client
 from werkzeug.local import LocalProxy as Proxy
 from xivo.auth_verifier import no_auth, required_acl, required_tenant
+from xivo.rest_api_helpers import APIException
 from xivo.status import Status, StatusDict
+from xivo.tenant_flask_helpers import user
 
 from .config import AuthConfig
 from .exception import MasterTenantNotInitiatedException
@@ -30,6 +32,14 @@ def client() -> Client:
     if not auth_client:
         auth_client = Client(**cast('AuthConfig', auth_config))
     return auth_client
+
+
+def get_user_uuid() -> str:
+    user_uuid = user.uuid
+    if not user_uuid:
+        raise APIException(401, 'This token has no user UUID', 'invalid-token')
+
+    return user_uuid
 
 
 F = TypeVar('F', bound=Callable[..., Any])

--- a/wazo_dird/plugins/default_json/http.py
+++ b/wazo_dird/plugins/default_json/http.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -12,8 +12,7 @@ from flask_restful import reqparse
 from requests.exceptions import HTTPError
 from xivo.tenant_flask_helpers import Tenant
 
-from wazo_dird import auth
-from wazo_dird.auth import required_acl
+from wazo_dird.auth import get_user_uuid, required_acl
 from wazo_dird.exception import (
     NoSuchProfile,
     NoSuchProfileAPIException,
@@ -83,8 +82,7 @@ class Lookup(LegacyAuthResource, DisplayAwareResource):
             return e.body, e.status_code
 
         token = request.headers['X-Auth-Token']
-        token_infos = auth.client().token.get(token)
-        user_uuid = token_infos['metadata']['uuid']
+        user_uuid = get_user_uuid()
 
         raw_results = self.lookup_service.lookup(
             cast(ProfileConfig, profile_config),
@@ -232,12 +230,11 @@ class FavoritesRead(LegacyAuthResource, DisplayAwareResource):
             return e.body, e.status_code
 
         token = request.headers.get('X-Auth-Token', '')
-        token_infos = auth.client().token.get(token)
 
         try:
             raw_results = self.favorites_service.favorites(
                 cast(ProfileConfig, profile_config),
-                token_infos['metadata']['uuid'],
+                get_user_uuid(),
                 token,
             )
         except self.favorites_service.NoSuchProfileException as e:
@@ -255,13 +252,10 @@ class FavoritesWrite(LegacyAuthResource):
     def put(
         self, directory: str, contact: str
     ) -> tuple[str, int] | tuple[dict[str, Any], int]:
-        token = request.headers.get('X-Auth-Token', '')
-        token_infos = auth.client().token.get(token)
-
         tenant = Tenant.autodetect()
         try:
             self.favorites_service.new_favorite(
-                tenant.uuid, directory, contact, token_infos['metadata']['uuid']
+                tenant.uuid, directory, contact, get_user_uuid()
             )
         except self.favorites_service.DuplicatedFavoriteException:
             return _error(409, 'Adding this favorite would create a duplicate')
@@ -273,13 +267,10 @@ class FavoritesWrite(LegacyAuthResource):
     def delete(
         self, directory: str, contact: str
     ) -> tuple[str, int] | tuple[dict[str, Any], int]:
-        token = request.headers.get('X-Auth-Token', '')
-        token_infos = auth.client().token.get(token)
-
         tenant = Tenant.autodetect()
         try:
             self.favorites_service.remove_favorite(
-                tenant.uuid, directory, contact, token_infos['metadata']['uuid']
+                tenant.uuid, directory, contact, get_user_uuid()
             )
             return '', 204
         except (
@@ -309,9 +300,6 @@ class Personal(LegacyAuthResource, DisplayAwareResource):
     @required_acl('dird.directories.personal.{profile}.read')
     def get(self, profile: str) -> dict[str, Any] | tuple[dict[str, Any], int]:
         logger.debug('Listing personal with profile %s', profile)
-        token = request.headers.get('X-Auth-Token', '')
-        token_infos = auth.client().token.get(token)
-
         tenant = Tenant.autodetect()
         try:
             profile_config = self.profile_service.get_by_name(tenant.uuid, profile)
@@ -319,13 +307,12 @@ class Personal(LegacyAuthResource, DisplayAwareResource):
         except OldAPIException as e:
             return e.body, e.status_code
 
-        raw_results = self.personal_service.list_contacts(
-            tenant.uuid, token_infos['metadata']['uuid']
-        )
+        user_uuid = get_user_uuid()
+        raw_results = self.personal_service.list_contacts(tenant.uuid, user_uuid)
 
         try:
             favorites = self.favorite_service.favorite_ids(
-                cast(ProfileConfig, profile_config), token_infos['metadata']['uuid']
+                cast(ProfileConfig, profile_config), user_uuid
             ).by_name
         except self.favorite_service.NoSuchProfileException as e:
             return _error(404, str(e))

--- a/wazo_dird/plugins/graphql/plugin.py
+++ b/wazo_dird/plugins/graphql/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -12,7 +12,7 @@ from wazo_auth_client.exceptions import MissingPermissionsTokenException
 from xivo.auth_verifier import AuthServerUnreachable, Unauthorized
 from xivo.flask.headers import extract_token_id_from_header
 from xivo.rest_api_helpers import APIException
-from xivo.tenant_helpers import Tenant
+from xivo.tenant_flask_helpers import Tenant
 
 from wazo_dird import BaseViewPlugin, http_server
 
@@ -44,7 +44,7 @@ class AuthorizationMiddleware:
         root_field = info.field_name
         required_acl = f'dird.graphql.{root_field}'
         try:
-            tenant = Tenant.autodetect(self._auth_client)
+            tenant = Tenant.autodetect()
         except AuthServerUnreachable as e:
             host = self._auth_config['host']
             port = self._auth_config['port']

--- a/wazo_dird/plugins/graphql/resolver.py
+++ b/wazo_dird/plugins/graphql/resolver.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -6,8 +6,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 from graphql import Undefined
+from xivo.rest_api_helpers import APIException
 
-from wazo_dird import auth
+from wazo_dird.auth import get_user_uuid
 from wazo_dird.exception import NoSuchProfile, NoSuchProfileAPIException
 
 from . import schema
@@ -48,9 +49,10 @@ class Resolver:
     def get_user_me(
         self, root: _SourceResult, info: ResolveInfo, **args: Any
     ) -> dict[str, Any]:
-        token_info = auth.client().token.get(info.context['token_id'])
-        metadata = token_info['metadata']
-        info.context['user_uuid'] = metadata['uuid']
+        try:
+            info.context['user_uuid'] = get_user_uuid()
+        except APIException as e:
+            raise graphql_error_from_api_exception(e) from e
         return {}
 
     def get_user_me_uuid(

--- a/wazo_dird/plugins/personal/http.py
+++ b/wazo_dird/plugins/personal/http.py
@@ -9,15 +9,13 @@ import logging
 import re
 from collections.abc import Callable
 from time import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from flask import Response, request
 from flask_restful import reqparse
-from xivo.rest_api_helpers import APIException
 from xivo.tenant_flask_helpers import Tenant
 
-from wazo_dird import auth
-from wazo_dird.auth import required_acl
+from wazo_dird.auth import get_user_uuid, required_acl
 from wazo_dird.http import LegacyAuthResource, get_json_body
 
 if TYPE_CHECKING:
@@ -33,16 +31,6 @@ parser = reqparse.RequestParser()
 parser.add_argument('format', type=str, required=False, location='args')
 
 
-def _get_calling_user_uuid() -> str:
-    token = request.headers['X-Auth-Token']
-    token_infos = auth.client().token.get(token)
-    user_uuid = token_infos.get('metadata').get('uuid')
-    if not user_uuid:
-        raise APIException(401, 'This token has no user UUID', 'invalid-token')
-
-    return cast(str, user_uuid)
-
-
 class PersonalAll(LegacyAuthResource):
     personal_service: _PersonalService
 
@@ -52,7 +40,7 @@ class PersonalAll(LegacyAuthResource):
 
     @required_acl('dird.personal.create')
     def post(self) -> tuple[dict[str, Any] | None, int]:
-        user_uuid = _get_calling_user_uuid()
+        user_uuid = get_user_uuid()
         tenant_uuid = Tenant.autodetect().uuid
         contact = get_json_body()
         try:
@@ -75,7 +63,7 @@ class PersonalAll(LegacyAuthResource):
     def get(
         self,
     ) -> tuple[dict[str, Any], int] | tuple[str, int] | Response:
-        user_uuid = _get_calling_user_uuid()
+        user_uuid = get_user_uuid()
         try:
             contacts = self.personal_service.list_contacts_raw(
                 user_uuid, search_params=request.args
@@ -93,7 +81,7 @@ class PersonalAll(LegacyAuthResource):
 
     @required_acl('dird.personal.delete')
     def delete(self) -> tuple[str, int]:
-        user_uuid = _get_calling_user_uuid()
+        user_uuid = get_user_uuid()
 
         self.personal_service.purge_contacts(user_uuid)
 
@@ -158,7 +146,7 @@ class PersonalOne(LegacyAuthResource):
     def get(
         self, contact_id: str
     ) -> tuple[ContactInfo, int] | tuple[dict[str, Any], int]:
-        user_uuid = _get_calling_user_uuid()
+        user_uuid = get_user_uuid()
         try:
             contact = self.personal_service.get_contact(contact_id, user_uuid)
             return contact, 200
@@ -168,7 +156,7 @@ class PersonalOne(LegacyAuthResource):
 
     @required_acl('dird.personal.{contact_id}.update')
     def put(self, contact_id: str) -> tuple[dict[str, Any] | None, int]:
-        user_uuid = _get_calling_user_uuid()
+        user_uuid = get_user_uuid()
         tenant_uuid = Tenant.autodetect().uuid
         new_contact = get_json_body()
         try:
@@ -192,7 +180,7 @@ class PersonalOne(LegacyAuthResource):
 
     @required_acl('dird.personal.{contact_id}.delete')
     def delete(self, contact_id: str) -> tuple[str | dict[str, Any], int]:
-        user_uuid = _get_calling_user_uuid()
+        user_uuid = get_user_uuid()
         try:
             self.personal_service.remove_contact(contact_id, user_uuid)
             return '', 204
@@ -210,7 +198,7 @@ class PersonalImport(LegacyAuthResource):
 
     @required_acl('dird.personal.import.create')
     def post(self) -> tuple[dict[str, Any], int]:
-        user_uuid = _get_calling_user_uuid()
+        user_uuid = get_user_uuid()
         tenant_uuid = Tenant.autodetect().uuid
 
         charset = request.mimetype_params.get('charset', 'utf-8')


### PR DESCRIPTION
- **Reuse the request-scoped token instead of refetching it**
- **Add a wazo-auth request budget test**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication-related request handling across many API surfaces; behavior should be equivalent but depends on request-scoped user/tenant population matching the old token metadata reads.
> 
> **Overview**
> **Stops redundant wazo-auth token fetches** by introducing shared `get_user_uuid()` (from `xivo.tenant_flask_helpers.user`) and using it across directory JSON routes (lookup, favorites, personal), personal CRUD/import, and GraphQL `me` resolution instead of `auth.client().token.get(...)`. The local `_get_calling_user_uuid()` helper in personal HTTP is removed in favor of the shared helper; GraphQL auth middleware now calls `Tenant.autodetect()` without passing the auth client.
> 
> **Adds integration coverage** (`TestTokenRequestCount`) that asserts how many `/0.1/token` GET/HEAD calls occur per request for lookup, reverse, favorites, personal, and GraphQL—encoding the rule that verify still hits auth once and a full token fetch happens at most once when tenant or user UUID is not already available from headers/path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d45ef39c4d990e3e91ff1dd4a01e118d9c658f16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->