### PR TITLE
ITEM-594 PRODUCT-332: reuse the docker asset across integration test classes

### DIFF
--- a/integration_tests/assets/docker-compose.documentation.override.yml
+++ b/integration_tests/assets/docker-compose.documentation.override.yml
@@ -1,6 +1,0 @@
-services:
-  sync:
-    depends_on:
-      - dird
-    environment:
-      TARGETS: "dird:9489"

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -11,8 +11,11 @@ reads is the name of the fixture.
 """
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
 from suite.helpers import base
+from wazo_test_helpers.asset_launching_test_case import NoSuchService
 from wazo_test_helpers.pytest_asset import asset_fixture, register
 
 
@@ -23,8 +26,24 @@ def pytest_configure(config: pytest.Config) -> None:
 for _name, _asset_class in base.ASSET_CLASSES.items():
     globals()[_name] = asset_fixture(_asset_class)
 
-# `enable_mark_logs_fixture` is not enabled: it marks the logs of `cls.service`,
-# and the backend assets never start a dird container - their `sync` waits for
-# the mock alone - so it raises NoSuchService on each of their tests. The fixture
-# is autouse and every test file sits in this one directory, so a narrower
-# conftest cannot exclude them either.
+
+@pytest.fixture(autouse=True, scope='function')
+def mark_logs(request: pytest.FixtureRequest) -> Iterator[None]:
+    """Bracket each test in the logs of its `dird` container.
+
+    A few assets (`database`, `wazo_confd`, the `csv_ws_*` mocks) test a
+    backend directly and never start a `dird` container, so marking their
+    logs raises `NoSuchService`; skip those instead of failing the test.
+    """
+    cls = request.cls
+    if cls is None or not hasattr(cls, 'asset_cls'):
+        yield
+        return
+    test_name = f'{cls.__name__}.{request.function.__name__}'
+    try:
+        cls.asset_cls.mark_logs_test_start(test_name)
+    except NoSuchService:
+        yield
+        return
+    yield
+    cls.asset_cls.mark_logs_test_end(test_name)

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1,0 +1,30 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Give the suite the shared asset plugin of wazo_test_helpers.
+
+The plugin groups the test classes by the asset they ask for, starts each stack
+once, and stops it as soon as the next class needs another one. A test class
+asks for its stack with `asset = '<name>'`; see `suite/helpers/base.py`.
+
+One fixture is built for each asset class, because the marker that the plugin
+reads is the name of the fixture.
+"""
+from __future__ import annotations
+
+import pytest
+from suite.helpers import base
+from wazo_test_helpers.pytest_asset import asset_fixture, register
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    register(config)
+
+
+for _name, _asset_class in base.ASSET_CLASSES.items():
+    globals()[_name] = asset_fixture(_asset_class)
+
+# `enable_mark_logs_fixture` is not enabled: it marks the logs of `cls.service`,
+# and the backend assets never start a dird container - their `sync` waits for
+# the mock alone - so it raises NoSuchService on each of their tests. The fixture
+# is autouse and every test file sits in this one directory, so a narrower
+# conftest cannot exclude them either.

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1,14 +1,5 @@
 # Copyright 2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""Give the suite the shared asset plugin of wazo_test_helpers.
-
-The plugin groups the test classes by the asset they ask for, starts each stack
-once, and stops it as soon as the next class needs another one. A test class
-asks for its stack with `asset = '<name>'`; see `suite/helpers/base.py`.
-
-One fixture is built for each asset class, because the marker that the plugin
-reads is the name of the fixture.
-"""
 from __future__ import annotations
 
 from collections.abc import Iterator

--- a/integration_tests/performance_suite/test_graphql_load.py
+++ b/integration_tests/performance_suite/test_graphql_load.py
@@ -4,7 +4,7 @@
 import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack
-from typing import NamedTuple
+from typing import ClassVar, NamedTuple
 
 from wazo_dird_client import Client as DirdClient
 
@@ -121,6 +121,8 @@ def concurrent_p50_budget(num_extens: int) -> float:
 class _GraphQLLoadBase(BaseDirdIntegrationTest):
     asset = 'graphql_load'
     config_factory = new_null_config
+
+    stack: ClassVar[ExitStack]
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -11,6 +11,7 @@ from typing import ClassVar
 import requests
 import yaml
 from hamcrest import assert_that, equal_to, has_entries
+from sqlalchemy import inspect, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import scoped_session
 from wazo_dird_client import Client as DirdClient
@@ -75,13 +76,48 @@ class DBRunningTestCase(DirdAssetRunningTestCase):
         database.Base.metadata.create_all(bind=cls.engine)
 
     @classmethod
+    def clean_db(cls) -> None:
+        """Empty every table without touching the schema.
+
+        The schema of the db image comes from the alembic migrations. Dropping
+        it would let `create_all` rebuild a different one from the models - the
+        constraint names do not agree - so the tests would no longer run
+        against the schema that we install.
+        """
+        # `Base.metadata` belongs to the process, and `setUpClass` reflects each
+        # database into it. One session covers many assets, so the metadata
+        # ends up describing tables that the current database does not have.
+        existing = set(inspect(cls.engine).get_table_names())
+
+        with cls.engine.begin() as connection:
+            # DELETE takes a row lock. TRUNCATE needs an ACCESS EXCLUSIVE lock,
+            # so it would queue behind the queries that dird still has in
+            # flight and block the rest of the run.
+            connection.execute(text("SET LOCAL lock_timeout = '10s'"))
+            for table in reversed(database.Base.metadata.sorted_tables):
+                if table.name == 'alembic_version' or table.name not in existing:
+                    continue
+                connection.execute(table.delete())
+
+        # Reclaim the dead rows and refresh the planner statistics. Without
+        # this, a class that loads many contacts leaves the next one with a
+        # bloated table and stale statistics, and the phonebook queries become
+        # slow enough to time out.
+        with cls.engine.connect().execution_options(
+            isolation_level='AUTOCOMMIT'
+        ) as connection:
+            connection.execute(text('VACUUM (ANALYZE)'))
+
+    @classmethod
     def tearDownClass(cls):
+        # A failure of the cleanup must still release the connections and stop
+        # the stack, otherwise the next class of the same asset inherits the
+        # leak and every later class fails too.
         try:
-            database.Base.metadata.drop_all(bind=cls.engine)
-        except Exception:
-            pass
-        cls.engine.dispose()
-        super().tearDownClass()
+            cls.clean_db()
+        finally:
+            cls.engine.dispose()
+            super().tearDownClass()
 
     @classmethod
     def restart_postgres(cls):

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -4,10 +4,12 @@
 import os
 import random
 import string
+import unittest
 from collections.abc import Generator
 from contextlib import contextmanager
-from typing import ClassVar
+from typing import Any, ClassVar
 
+import pytest
 import requests
 import yaml
 from hamcrest import assert_that, equal_to, has_entries
@@ -51,9 +53,197 @@ START_TIMEOUT = int(os.getenv('INTEGRATION_TEST_TIMEOUT', '30'))
 DB_ECHO = os.getenv('DB_ECHO', '').lower() in ['true', '1']
 
 
-class DirdAssetRunningTestCase(AssetLaunchingTestCase):
+use_asset = pytest.mark.usefixtures
+
+
+class DirdAssetLaunchingTestCase(AssetLaunchingTestCase):
+    """Owns the lifecycle of one docker asset.
+
+    `wazo_test_helpers.pytest_asset` drives the subclasses from a session
+    fixture, so one stack serves every test class that asks for the same asset.
+    """
+
+    # These classes hold a stack, they hold no test.
+    __test__ = False
+
     assets_root = ASSET_ROOT
     service = 'dird'
+
+
+# `csv_with_no_unique_column` has no class: it names data files, not a stack.
+
+
+class AllRoutesAsset(DirdAssetLaunchingTestCase):
+    asset = 'all_routes'
+
+
+class CsvWithPipesAsset(DirdAssetLaunchingTestCase):
+    asset = 'csv_with_pipes'
+
+
+class CsvWsIso88591WithComaAsset(DirdAssetLaunchingTestCase):
+    asset = 'csv_ws_iso88591_with_coma'
+
+
+class CsvWsUtf8WithPipesWithSslAsset(DirdAssetLaunchingTestCase):
+    asset = 'csv_ws_utf8_with_pipes_with_ssl'
+
+
+class DatabaseAsset(DirdAssetLaunchingTestCase):
+    asset = 'database'
+
+
+class DirdGoogleAsset(DirdAssetLaunchingTestCase):
+    asset = 'dird_google'
+
+
+class DirdMicrosoftAsset(DirdAssetLaunchingTestCase):
+    asset = 'dird_microsoft'
+
+
+class DocumentationAsset(DirdAssetLaunchingTestCase):
+    asset = 'documentation'
+
+
+class GraphqlLoadAsset(DirdAssetLaunchingTestCase):
+    # `performance_suite/helpers` is a symlink on `suite/helpers`, so the
+    # performance tests need their asset here too.
+    asset = 'graphql_load'
+
+
+class HalfBrokenAsset(DirdAssetLaunchingTestCase):
+    asset = 'half_broken'
+
+
+class LdapAsset(DirdAssetLaunchingTestCase):
+    asset = 'ldap'
+
+
+class LdapCityAsset(DirdAssetLaunchingTestCase):
+    asset = 'ldap_city'
+
+
+class LdapServiceDownAsset(DirdAssetLaunchingTestCase):
+    asset = 'ldap_service_down'
+
+
+class LdapServiceInnactiveAsset(DirdAssetLaunchingTestCase):
+    asset = 'ldap_service_innactive'
+
+
+class MultipleSourcesAsset(DirdAssetLaunchingTestCase):
+    asset = 'multiple_sources'
+
+
+class PersonalOnlyAsset(DirdAssetLaunchingTestCase):
+    asset = 'personal_only'
+
+
+class PhonebookOnlyAsset(DirdAssetLaunchingTestCase):
+    asset = 'phonebook_only'
+
+
+class ServiceTimeoutAsset(DirdAssetLaunchingTestCase):
+    asset = 'service_timeout'
+
+
+class WazoConfdAsset(DirdAssetLaunchingTestCase):
+    asset = 'wazo_confd'
+
+
+class WazoNoConfdAsset(DirdAssetLaunchingTestCase):
+    asset = 'wazo_no_confd'
+
+
+class WazoUsersLateConfdAsset(DirdAssetLaunchingTestCase):
+    asset = 'wazo_users_late_confd'
+
+
+class WazoUsersMissingOneWazoAsset(DirdAssetLaunchingTestCase):
+    asset = 'wazo_users_missing_one_wazo'
+
+
+class WazoUsersMultipleWazoAsset(DirdAssetLaunchingTestCase):
+    asset = 'wazo_users_multiple_wazo'
+
+
+class WazoUsersTwoWorkingOne404Asset(DirdAssetLaunchingTestCase):
+    asset = 'wazo_users_two_working_one_404'
+
+
+class WazoUsersTwoWorkingOneTimeoutAsset(DirdAssetLaunchingTestCase):
+    asset = 'wazo_users_two_working_one_timeout'
+
+
+# The name of the asset is already on each class, so read it back from there.
+ASSET_CLASSES: dict[str, type[DirdAssetLaunchingTestCase]] = {
+    asset_class.asset: asset_class
+    for asset_class in DirdAssetLaunchingTestCase.__subclasses__()
+}
+
+
+class DirdAssetRunningTestCase(unittest.TestCase):
+    """Base of the test classes. It does not start anything itself.
+
+    A subclass names the stack it needs with `asset = '<name>'`. That gives it
+    the matching `asset_cls` and the `usefixtures` marker that the plugin reads
+    to group the classes and to start the stack once.
+    """
+
+    asset: ClassVar[str]
+    asset_cls: ClassVar[type[DirdAssetLaunchingTestCase]]
+    pytestmark: ClassVar[list[pytest.MarkDecorator]]
+    # A few tests build a path to an asset file, so they need this too.
+    assets_root = ASSET_ROOT
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        # bind the shared asset class
+        declared = cls.__dict__.get('asset')
+        if declared is not None:
+            if declared not in ASSET_CLASSES:
+                raise RuntimeError(
+                    f'{cls.__name__} asks for the unknown asset {declared!r}; '
+                    'add a subclass of DirdAssetLaunchingTestCase for it'
+                )
+            cls.asset_cls = ASSET_CLASSES[declared]
+
+        # Mark only the collected classes: pytest gathers `pytestmark` along the
+        # whole MRO and the plugin keeps the first, so a marker on a base class
+        # would win over the one of its subclasses.
+        asset = getattr(cls, 'asset', None)
+        if asset is not None and cls.__name__.startswith('Test'):
+            cls.pytestmark = [use_asset(asset)]
+
+    # The asset class owns the stack, so these reach it. They are the only
+    # methods of it that the tests use; `*args` avoids a copy of its signatures.
+    @classmethod
+    def service_port(cls, *args: Any, **kwargs: Any) -> Any:
+        return cls.asset_cls.service_port(*args, **kwargs)
+
+    @classmethod
+    def docker_exec(cls, *args: Any, **kwargs: Any) -> Any:
+        return cls.asset_cls.docker_exec(*args, **kwargs)
+
+    @classmethod
+    def restart_service(cls, *args: Any, **kwargs: Any) -> Any:
+        return cls.asset_cls.restart_service(*args, **kwargs)
+
+    @classmethod
+    def stop_service(cls, *args: Any, **kwargs: Any) -> Any:
+        return cls.asset_cls.stop_service(*args, **kwargs)
+
+    @classmethod
+    def start_service(cls, *args: Any, **kwargs: Any) -> Any:
+        return cls.asset_cls.start_service(*args, **kwargs)
+
+    @classmethod
+    def capture_logs(cls, *args: Any, **kwargs: Any) -> Any:
+        return cls.asset_cls.capture_logs(*args, **kwargs)
+
+    @classmethod
+    def _run_cmd(cls, *args: Any, **kwargs: Any) -> Any:
+        return cls.asset_cls._run_cmd(*args, **kwargs)
 
 
 class DBRunningTestCase(DirdAssetRunningTestCase):
@@ -77,32 +267,21 @@ class DBRunningTestCase(DirdAssetRunningTestCase):
 
     @classmethod
     def clean_db(cls) -> None:
-        """Empty every table without touching the schema.
-
-        The schema of the db image comes from the alembic migrations. Dropping
-        it would let `create_all` rebuild a different one from the models - the
-        constraint names do not agree - so the tests would no longer run
-        against the schema that we install.
-        """
-        # `Base.metadata` belongs to the process, and `setUpClass` reflects each
-        # database into it. One session covers many assets, so the metadata
-        # ends up describing tables that the current database does not have.
+        """Empty every table, keeping the schema that alembic installed."""
+        # ensure a fresh current view of db tables
         existing = set(inspect(cls.engine).get_table_names())
 
         with cls.engine.begin() as connection:
-            # DELETE takes a row lock. TRUNCATE needs an ACCESS EXCLUSIVE lock,
-            # so it would queue behind the queries that dird still has in
-            # flight and block the rest of the run.
+            # use delete to take a row lock instead of an exclusive lock
+            # (avoid deadlock)
             connection.execute(text("SET LOCAL lock_timeout = '10s'"))
             for table in reversed(database.Base.metadata.sorted_tables):
                 if table.name == 'alembic_version' or table.name not in existing:
                     continue
                 connection.execute(table.delete())
 
-        # Reclaim the dead rows and refresh the planner statistics. Without
-        # this, a class that loads many contacts leaves the next one with a
-        # bloated table and stale statistics, and the phonebook queries become
-        # slow enough to time out.
+        # update stats so previous data churn does not impact planning on the
+        # next test run
         with cls.engine.connect().execution_options(
             isolation_level='AUTOCOMMIT'
         ) as connection:
@@ -110,12 +289,7 @@ class DBRunningTestCase(DirdAssetRunningTestCase):
 
     @classmethod
     def analyze_db(cls) -> None:
-        """Refresh the planner statistics after a bulk load.
-
-        `clean_db` leaves the statistics of empty tables behind. A class that
-        loads many rows must refresh them, otherwise the planner still believes
-        the tables are empty and chooses a plan that is far too slow.
-        """
+        """Refresh the planner statistics after a bulk load."""
         with cls.engine.connect().execution_options(
             isolation_level='AUTOCOMMIT'
         ) as connection:
@@ -139,31 +313,6 @@ class DBRunningTestCase(DirdAssetRunningTestCase):
         cls.setup_db_session()
         database = DBUserClient(cls.db_uri)
         until.true(database.is_up, timeout=5, message='Postgres did not come back up')
-
-    @classmethod
-    def restart_dird(cls):
-        cls.restart_service('dird')
-        cls.port = cls.service_port(9489, 'dird')
-        cls.dird = cls.make_dird(VALID_TOKEN_MAIN_TENANT)
-
-    @classmethod
-    @contextmanager
-    def dird_with_config(cls, config: dict) -> Generator[None, None, None]:
-        filesystem = FileSystemClient(
-            execute=cls.docker_exec,
-            service_name='dird',
-            root=True,
-        )
-        name = ''.join(random.choice(string.ascii_lowercase) for _ in range(6))
-        config_file = f'/etc/wazo-dird/conf.d/10-{name}.yml'
-        content = yaml.dump(config)
-        try:
-            with filesystem.file_(config_file, content=content):
-                cls.restart_dird()
-                yield
-        finally:
-            cls.restart_dird()
-            cls.wait_strategy.wait(cls.dird)
 
 
 class RequestUtilMixin:
@@ -229,6 +378,31 @@ class BaseDirdIntegrationTest(RequestUtilMixin, DBRunningTestCase):
     def tearDownClass(cls):
         cls.config.tear_down()
         super().tearDownClass()
+
+    @classmethod
+    def restart_dird(cls):
+        cls.restart_service('dird')
+        cls.port = cls.service_port(9489, 'dird')
+        cls.dird = cls.make_dird(VALID_TOKEN_MAIN_TENANT)
+
+    @classmethod
+    @contextmanager
+    def dird_with_config(cls, config: dict) -> Generator[None, None, None]:
+        filesystem = FileSystemClient(
+            execute=cls.docker_exec,
+            service_name='dird',
+            root=True,
+        )
+        name = ''.join(random.choice(string.ascii_lowercase) for _ in range(6))
+        config_file = f'/etc/wazo-dird/conf.d/10-{name}.yml'
+        content = yaml.dump(config)
+        try:
+            with filesystem.file_(config_file, content=content):
+                cls.restart_dird()
+                yield
+        finally:
+            cls.restart_dird()
+            cls.wait_strategy.wait(cls.dird)
 
     @classmethod
     def make_dird(cls, token: str) -> DirdClient:

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -109,6 +109,19 @@ class DBRunningTestCase(DirdAssetRunningTestCase):
             connection.execute(text('VACUUM (ANALYZE)'))
 
     @classmethod
+    def analyze_db(cls) -> None:
+        """Refresh the planner statistics after a bulk load.
+
+        `clean_db` leaves the statistics of empty tables behind. A class that
+        loads many rows must refresh them, otherwise the planner still believes
+        the tables are empty and chooses a plan that is far too slow.
+        """
+        with cls.engine.connect().execution_options(
+            isolation_level='AUTOCOMMIT'
+        ) as connection:
+            connection.execute(text('ANALYZE'))
+
+    @classmethod
     def tearDownClass(cls):
         # A failure of the cleanup must still release the connections and stop
         # the stack, otherwise the next class of the same asset inherits the

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -262,8 +262,6 @@ class DBRunningTestCase(DirdAssetRunningTestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.setup_db_session()
-        database.Base.metadata.reflect(bind=cls.engine)
-        database.Base.metadata.create_all(bind=cls.engine)
 
     @classmethod
     def clean_db(cls) -> None:

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -370,8 +370,10 @@ class BaseDirdIntegrationTest(RequestUtilMixin, DBRunningTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.config.tear_down()
-        super().tearDownClass()
+        try:
+            cls.config.tear_down()
+        finally:
+            super().tearDownClass()
 
     @classmethod
     def restart_dird(cls):
@@ -458,11 +460,13 @@ class BaseDirdIntegrationTest(RequestUtilMixin, DBRunningTestCase):
     @contextmanager
     def auth_stopped(cls):
         cls.stop_service('auth')
-        yield
-        cls.start_service('auth')
-        auth = cls.make_mock_auth()
-        until.true(auth.is_up, timeout=START_TIMEOUT)
-        cls.configure_wazo_auth()
+        try:
+            yield
+        finally:
+            cls.start_service('auth')
+            auth = cls.make_mock_auth()
+            until.true(auth.is_up, timeout=START_TIMEOUT)
+            cls.configure_wazo_auth()
 
     @classmethod
     def get_client(cls, token: str = VALID_TOKEN_MAIN_TENANT) -> DirdClient:

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -101,10 +101,6 @@ class DirdMicrosoftAsset(DirdAssetLaunchingTestCase):
     asset = 'dird_microsoft'
 
 
-class DocumentationAsset(DirdAssetLaunchingTestCase):
-    asset = 'documentation'
-
-
 class GraphqlLoadAsset(DirdAssetLaunchingTestCase):
     # `performance_suite/helpers` is a symlink on `suite/helpers`, so the
     # performance tests need their asset here too.

--- a/integration_tests/suite/helpers/fixtures/db.py
+++ b/integration_tests/suite/helpers/fixtures/db.py
@@ -1,11 +1,33 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from functools import wraps
 
 from wazo_dird import exception
+from wazo_dird.database import models
 
 from ..utils import new_uuid, random_string
+
+
+def tenant(**tenant_args):
+    tenant_args.setdefault('tenant_uuid', new_uuid())
+
+    def decorator(decorated):
+        @wraps(decorated)
+        def wrapper(self, *args, **kwargs):
+            tenant = self.tenant_crud.create(**tenant_args)
+            try:
+                return decorated(self, tenant, *args, **kwargs)
+            finally:
+                # `TenantCRUD` has no delete.
+                with self.tenant_crud.new_session() as session:
+                    session.query(models.Tenant).filter(
+                        models.Tenant.uuid == tenant['uuid']
+                    ).delete()
+
+        return wrapper
+
+    return decorator
 
 
 def display(**display_args):

--- a/integration_tests/suite/helpers/fixtures/db.py
+++ b/integration_tests/suite/helpers/fixtures/db.py
@@ -1,6 +1,7 @@
 # Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from contextlib import contextmanager
 from functools import wraps
 
 from wazo_dird import exception
@@ -9,21 +10,26 @@ from wazo_dird.database import models
 from ..utils import new_uuid, random_string
 
 
-def tenant(**tenant_args):
+@contextmanager
+def _created_tenant(dao, **tenant_args):
     tenant_args.setdefault('tenant_uuid', new_uuid())
+    created = dao.tenant_crud.create(**tenant_args)
+    try:
+        yield created
+    finally:
+        # `TenantCRUD` has no delete.
+        with dao.tenant_crud.new_session() as session:
+            session.query(models.Tenant).filter(
+                models.Tenant.uuid == created['uuid']
+            ).delete()
 
+
+def tenant(**tenant_args):
     def decorator(decorated):
         @wraps(decorated)
         def wrapper(self, *args, **kwargs):
-            tenant = self.tenant_crud.create(**tenant_args)
-            try:
-                return decorated(self, tenant, *args, **kwargs)
-            finally:
-                # `TenantCRUD` has no delete.
-                with self.tenant_crud.new_session() as session:
-                    session.query(models.Tenant).filter(
-                        models.Tenant.uuid == tenant['uuid']
-                    ).delete()
+            with _created_tenant(self, **tenant_args) as created:
+                return decorated(self, created, *args, **kwargs)
 
         return wrapper
 

--- a/integration_tests/suite/test_asset_wiring.py
+++ b/integration_tests/suite/test_asset_wiring.py
@@ -1,0 +1,106 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Check that each test class asks the asset plugin for the right stack.
+
+These need no container. They guard the wiring of `base.DirdAssetRunningTestCase`
+against a silent mistake: pytest gathers `pytestmark` along the whole MRO and the
+plugin keeps the first marker it finds, so a marker on a base class would send
+every subclass to the stack of that base class.
+"""
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from pathlib import Path
+
+import pytest
+
+from .helpers import base
+
+
+def _collected_subclasses() -> list[type[base.DirdAssetRunningTestCase]]:
+    """Every class that pytest collects, that is every one named `Test*`.
+
+    Import the whole suite first: this module comes early in the alphabet, so
+    most of the test classes would not exist yet.
+    """
+    suite = importlib.import_module(__package__)
+    for module in pkgutil.iter_modules(suite.__path__):
+        if module.name.startswith('test_'):
+            importlib.import_module(f'{__package__}.{module.name}')
+
+    def walk(cls):
+        for sub in cls.__subclasses__():
+            yield sub
+            yield from walk(sub)
+
+    return [
+        cls
+        for cls in walk(base.DirdAssetRunningTestCase)
+        if cls.__name__.startswith('Test')
+    ]
+
+
+def _own_usefixtures(cls: type) -> list[str]:
+    """The markers that `cls` itself declares, not the ones it inherits."""
+    return [
+        str(mark.args[0])
+        for mark in cls.__dict__.get('pytestmark', [])
+        if mark.name == 'usefixtures' and mark.args
+    ]
+
+
+def _marked_ancestors(cls: type) -> list[type]:
+    return [ancestor for ancestor in cls.__mro__ if _own_usefixtures(ancestor)]
+
+
+def test_every_asset_has_a_compose_file() -> None:
+    # A name with no override file builds a fixture that cannot start, and the
+    # failure would only appear when a test asks for that fixture.
+    overrides = {
+        path.name.removeprefix('docker-compose.').removesuffix('.override.yml')
+        for path in Path(base.ASSET_ROOT).glob('docker-compose.*.override.yml')
+    }
+    assert set(base.ASSET_CLASSES) - overrides == set()
+
+
+def test_every_asset_class_is_registered_once() -> None:
+    # `ASSET_CLASSES` is keyed by `asset`, so two classes that name the same
+    # asset would silently leave one of them out, and its fixture with it.
+    subclasses = base.DirdAssetLaunchingTestCase.__subclasses__()
+    assert len(base.ASSET_CLASSES) == len(subclasses)
+    for name, asset_class in base.ASSET_CLASSES.items():
+        assert asset_class.asset == name
+        assert asset_class.service == 'dird'
+        # A stack holder that pytest collects would run as an empty test class.
+        assert asset_class.__test__ is False
+
+
+def test_collected_classes_ask_for_the_asset_they_declare() -> None:
+    wrong = {
+        f'{cls.__module__}.{cls.__name__}': (
+            getattr(cls, 'asset', None),
+            _own_usefixtures(cls),
+        )
+        for cls in _collected_subclasses()
+        if _own_usefixtures(cls) != [getattr(cls, 'asset', None)]
+    }
+    assert not wrong, f'these classes would use the wrong stack: {wrong}'
+
+
+def test_only_the_collected_class_of_a_chain_carries_a_marker() -> None:
+    # pytest gathers `pytestmark` along the MRO and the plugin keeps the first
+    # marker, so a second marked class in a chain would decide for the others.
+    several = {
+        f'{cls.__module__}.{cls.__name__}': [c.__name__ for c in _marked_ancestors(cls)]
+        for cls in _collected_subclasses()
+        if len(_marked_ancestors(cls)) != 1
+    }
+    assert not several, f'more than one marker in the chain of: {several}'
+
+
+def test_an_unknown_asset_is_refused() -> None:
+    with pytest.raises(RuntimeError, match='unknown asset'):
+
+        class TestWithATypo(base.DirdAssetRunningTestCase):
+            asset = 'ths_asset_does_not_exist'

--- a/integration_tests/suite/test_auth_requests.py
+++ b/integration_tests/suite/test_auth_requests.py
@@ -1,6 +1,8 @@
 # Copyright 2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from typing import ClassVar
+
 from hamcrest import assert_that, equal_to, has_key, has_length, not_
 from wazo_test_helpers.auth import AuthClient as MockAuthClient
 from wazo_test_helpers.auth import MockUserToken
@@ -22,6 +24,9 @@ class TestTokenRequestCount(BaseDirdIntegrationTest):
 
     asset = 'all_routes'
     config_factory = new_csv_with_multiple_displays_config
+
+    auth: ClassVar[MockAuthClient]
+    token: ClassVar[str]
 
     @classmethod
     def setUpClass(cls):

--- a/integration_tests/suite/test_csv_ws_backend.py
+++ b/integration_tests/suite/test_csv_ws_backend.py
@@ -8,6 +8,9 @@ from .helpers.utils import BackendWrapper
 
 
 class _BaseCSVWSBackend(DirdAssetRunningTestCase):
+    def backend_config(self) -> dict:
+        raise NotImplementedError
+
     def setUp(self):
         self.backend = BackendWrapper('csv_ws', {'config': self.backend_config()})
 

--- a/integration_tests/suite/test_database.py
+++ b/integration_tests/suite/test_database.py
@@ -91,8 +91,6 @@ def _database_session(request):
     global Session
     request.getfixturevalue('database')
     DBStarter.setUpClass()
-    database.Base.metadata.drop_all(bind=DBStarter.engine)
-    database.Base.metadata.create_all(bind=DBStarter.engine)
     Session = DBStarter.Session
     yield
     DBStarter.tearDownClass()

--- a/integration_tests/suite/test_database.py
+++ b/integration_tests/suite/test_database.py
@@ -105,6 +105,7 @@ class _BaseTest(unittest.TestCase):
         self.display_crud = database.DisplayCRUD(Session)
         self.profile_crud = database.ProfileCRUD(Session)
         self.source_crud = database.SourceCRUD(Session)
+        self.tenant_crud = database.TenantCRUD(Session)
 
         self._contact_1 = {
             'firtname': 'Finley',
@@ -179,7 +180,10 @@ class _BasePhonebookCRUDTest(_BaseTest):
 
 
 class TestBaseDAO(_BaseTest):
-    def test_that_an_unexpected_error_does_not_block_the_current_Session(self):
+    # The phonebook needs its tenant: the migrations declare `tenant_uuid`
+    # NOT NULL, with a foreign key on the tenant.
+    @fixtures.tenant()
+    def test_that_an_unexpected_error_does_not_block_the_current_Session(self, tenant):
         dao = base.BaseDAO(Session)
 
         try:
@@ -194,8 +198,7 @@ class TestBaseDAO(_BaseTest):
 
         try:
             with dao.new_session() as s:
-                phonebook = database.Phonebook(name='bar')
-                s.add(phonebook)
+                s.add(database.Phonebook(name='bar', tenant_uuid=tenant['uuid']))
         except exc.InvalidRequestError:
             self.fail('Should not raise')
 

--- a/integration_tests/suite/test_database.py
+++ b/integration_tests/suite/test_database.py
@@ -82,20 +82,20 @@ class DBStarter(DBRunningTestCase):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def _database_session(request):
+def _database_session():
     """Open the session once the `database` stack is up.
 
-    The stack belongs to the asset plugin, so it must be asked for through the
-    fixture; `setup_module` would run before it.
+    `_BaseTest`'s `usefixtures('database')` mark already brings the stack up
+    before this, a module-scoped fixture, runs.
     """
     global Session
-    request.getfixturevalue('database')
     DBStarter.setUpClass()
     Session = DBStarter.Session
     yield
     DBStarter.tearDownClass()
 
 
+@pytest.mark.usefixtures('database')
 class _BaseTest(unittest.TestCase):
     _contact_1: Any
     _contact_2: Any

--- a/integration_tests/suite/test_database.py
+++ b/integration_tests/suite/test_database.py
@@ -8,6 +8,7 @@ from contextlib import closing, contextmanager
 from typing import Any, cast
 from unittest.mock import ANY
 
+import pytest
 from hamcrest import (
     any_of,
     assert_that,
@@ -80,15 +81,20 @@ class DBStarter(DBRunningTestCase):
     asset = 'database'
 
 
-def setup_module():
+@pytest.fixture(scope='module', autouse=True)
+def _database_session(request):
+    """Open the session once the `database` stack is up.
+
+    The stack belongs to the asset plugin, so it must be asked for through the
+    fixture; `setup_module` would run before it.
+    """
     global Session
+    request.getfixturevalue('database')
     DBStarter.setUpClass()
     database.Base.metadata.drop_all(bind=DBStarter.engine)
     database.Base.metadata.create_all(bind=DBStarter.engine)
     Session = DBStarter.Session
-
-
-def teardown_module():
+    yield
     DBStarter.tearDownClass()
 
 

--- a/integration_tests/suite/test_dird_phonebook_backend.py
+++ b/integration_tests/suite/test_dird_phonebook_backend.py
@@ -8,6 +8,7 @@ from typing import cast
 from unittest.mock import Mock
 from uuid import uuid4
 
+import pytest
 from hamcrest import assert_that, contains_exactly, contains_inanyorder, equal_to
 
 from wazo_dird import database
@@ -24,15 +25,20 @@ class DBStarter(DBRunningTestCase):
     asset = 'database'
 
 
-def setup_module():
+@pytest.fixture(scope='module', autouse=True)
+def _database_session(request):
+    """Open the session once the `database` stack is up.
+
+    The stack belongs to the asset plugin, so it must be asked for through the
+    fixture; `setup_module` would run before it.
+    """
     global Session
     global DB_URI
+    request.getfixturevalue('database')
     DBStarter.setUpClass()
     Session = DBStarter.Session
     DB_URI = DBStarter.db_uri
-
-
-def teardown_module():
+    yield
     DBStarter.tearDownClass()
 
 

--- a/integration_tests/suite/test_dird_phonebook_backend.py
+++ b/integration_tests/suite/test_dird_phonebook_backend.py
@@ -26,15 +26,14 @@ class DBStarter(DBRunningTestCase):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def _database_session(request):
+def _database_session():
     """Open the session once the `database` stack is up.
 
-    The stack belongs to the asset plugin, so it must be asked for through the
-    fixture; `setup_module` would run before it.
+    `TestPhonebookBackend`'s `usefixtures('database')` mark already brings
+    the stack up before this, a module-scoped fixture, runs.
     """
     global Session
     global DB_URI
-    request.getfixturevalue('database')
     DBStarter.setUpClass()
     Session = DBStarter.Session
     DB_URI = DBStarter.db_uri
@@ -67,6 +66,7 @@ class ContactInfo(_ContactInfo):
 contacts: list[ContactInfo] = []
 
 
+@pytest.mark.usefixtures('database')
 class TestPhonebookBackend(unittest.TestCase):
     def setUp(self):
         global contacts

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -14,7 +14,7 @@ logger.setLevel(logging.INFO)
 
 
 class TestDocumentation(DirdAssetRunningTestCase):
-    asset = 'documentation'
+    asset = 'phonebook_only'
 
     def test_documentation_errors(self):
         port = self.service_port(9489, 'dird')

--- a/integration_tests/suite/test_favorites.py
+++ b/integration_tests/suite/test_favorites.py
@@ -3,6 +3,7 @@
 
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from typing import ClassVar
 
 from hamcrest import (
     any_of,
@@ -31,6 +32,10 @@ from .helpers.constants import MAIN_TENANT, TENANT_UUID_2, VALID_TOKEN_MAIN_TENA
 class _BaseMultiTokenFavoriteTest(BaseDirdIntegrationTest):
     asset = 'all_routes'
     config_factory = new_csv_with_multiple_displays_config
+
+    token_1: ClassVar[str]
+    token_2: ClassVar[str]
+    token_3: ClassVar[str]
 
     @classmethod
     def setUpClass(cls):
@@ -267,6 +272,9 @@ class TestFavoritesInPersonalResults(PersonalOnlyTestCase):
 
 
 class TestFavoritesBusEvents(PersonalOnlyTestCase):
+    token_1: ClassVar[str]
+    token_2: ClassVar[str]
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/integration_tests/suite/test_google.py
+++ b/integration_tests/suite/test_google.py
@@ -1,6 +1,8 @@
 # Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from typing import ClassVar
+
 import urllib3
 from hamcrest import assert_that, contains_exactly, has_entries, has_item
 from wazo_test_helpers.auth import AuthClient as AuthMock
@@ -219,6 +221,12 @@ GOOGLE_SEARCH_LIST = {
 
 class TestGooglePlugin(BaseDirdIntegrationTest):
     asset = 'dird_google'
+
+    auth_client_mock: ClassVar[AuthMock]
+    source_uuid: ClassVar[str]
+    display_uuid: ClassVar[str]
+    profile_uuid: ClassVar[str]
+
     GOOGLE_EXTERNAL_AUTH = {
         "access_token": "an-access-token",
         "scope": "a-scope",

--- a/integration_tests/suite/test_google.py
+++ b/integration_tests/suite/test_google.py
@@ -283,12 +283,14 @@ class TestGooglePlugin(BaseDirdIntegrationTest):
 
     @classmethod
     def tearDownClass(cls):
-        client = cls.get_client()
-        cls.auth_client_mock.reset_external_auth()
-        client.backends.delete_source('google', cls.source_uuid)
-        client.displays.delete(cls.display_uuid)
-        client.profiles.delete(cls.profile_uuid)
-        super().tearDownClass()
+        try:
+            client = cls.get_client()
+            cls.auth_client_mock.reset_external_auth()
+            client.backends.delete_source('google', cls.source_uuid)
+            client.displays.delete(cls.display_uuid)
+            client.profiles.delete(cls.profile_uuid)
+        finally:
+            super().tearDownClass()
 
     @fixtures.google_result(GOOGLE_CONTACT_LIST, GOOGLE_SEARCH_LIST)
     def test_plugin_lookup(self, google_api):

--- a/integration_tests/suite/test_graphql.py
+++ b/integration_tests/suite/test_graphql.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from contextlib import contextmanager
+from typing import ClassVar
 
 from hamcrest import (
     any_of,
@@ -26,6 +27,9 @@ from .helpers.constants import MAIN_TENANT, VALID_TOKEN, VALID_TOKEN_NO_ACL
 class TestGraphQL(BaseDirdIntegrationTest):
     asset = 'all_routes'
     config_factory = new_csv_with_multiple_displays_config
+
+    auth: ClassVar[MockAuthClient]
+    main_tenant_token: ClassVar[str]
 
     @classmethod
     def setUpClass(cls):
@@ -434,6 +438,9 @@ class TestGraphQL(BaseDirdIntegrationTest):
 class TestGraphQLWazoBackend(BaseDirdIntegrationTest):
     asset = 'wazo_users_multiple_wazo'
     config_factory = new_wazo_users_config
+
+    auth: ClassVar[MockAuthClient]
+    main_tenant_token: ClassVar[str]
 
     @classmethod
     def setUpClass(cls):

--- a/integration_tests/suite/test_office365_backend.py
+++ b/integration_tests/suite/test_office365_backend.py
@@ -1,6 +1,7 @@
 # Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from typing import ClassVar
 from unittest.mock import Mock
 
 import requests
@@ -78,6 +79,12 @@ OFFICE365_CONTACTS_WITHOUT_GIVEN_NAME = {
 
 class BaseOffice365TestCase(DirdAssetRunningTestCase):
     service = 'dird'
+
+    # The subclasses give these their value.
+    BACKEND: ClassVar[str]
+
+    def config(self) -> dict:
+        raise NotImplementedError
 
     MICROSOFT_EXTERNAL_AUTH = {
         "access_token": "an-access-token",

--- a/integration_tests/suite/test_phonebook_http.py
+++ b/integration_tests/suite/test_phonebook_http.py
@@ -787,6 +787,7 @@ class TestPluginLookup(BasePhonebookCRUDTestCase):
         )
         assert not errors
         assert len(cls.contacts) == cls.contact_count
+        cls.analyze_db()
 
         source_body = {
             'first_matched_columns': ['number', 'firstname', 'lastname'],
@@ -917,6 +918,7 @@ class TestGetContactsLoad(BasePhonebookCRUDTestCase):
             ],
         )
         assert not errors
+        cls.analyze_db()
 
     @classmethod
     def tearDownClass(self):

--- a/integration_tests/suite/test_phonebook_http.py
+++ b/integration_tests/suite/test_phonebook_http.py
@@ -571,9 +571,11 @@ class TestGetContacts(BasePhonebookCRUDTestCase):
         assert not errors
 
     @classmethod
-    def tearDownClass(self):
-        self.stack.close()
-        super().tearDownClass()
+    def tearDownClass(cls):
+        try:
+            cls.stack.close()
+        finally:
+            super().tearDownClass()
 
     def test_get_all(self):
         client = self.get_client(VALID_TOKEN_MAIN_TENANT)
@@ -845,8 +847,10 @@ class TestPluginLookup(BasePhonebookCRUDTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.stack.close()
-        super().tearDownClass()
+        try:
+            cls.stack.close()
+        finally:
+            super().tearDownClass()
 
     def test_plugin_lookup(self):
         result = self.client.directories.lookup(term=' 5', profile='default')
@@ -934,9 +938,11 @@ class TestGetContactsLoad(BasePhonebookCRUDTestCase):
         cls.analyze_db()
 
     @classmethod
-    def tearDownClass(self):
-        self.stack.close()
-        super().tearDownClass()
+    def tearDownClass(cls):
+        try:
+            cls.stack.close()
+        finally:
+            super().tearDownClass()
 
     def test_get_paginated(self):
         client = self.get_client(VALID_TOKEN_MAIN_TENANT)

--- a/integration_tests/suite/test_phonebook_http.py
+++ b/integration_tests/suite/test_phonebook_http.py
@@ -5,7 +5,7 @@ import logging
 import time
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
-from typing import Any, TypedDict
+from typing import Any, ClassVar, TypedDict
 from unittest.mock import ANY
 
 import requests
@@ -88,6 +88,19 @@ def phonebook(
 
 class BasePhonebookCRUDTestCase(BasePhonebookTestCase):
     asset = 'all_routes'
+
+    # `setUpClass` of the subclasses sets these.
+    stack: ClassVar[ExitStack]
+    phonebook: ClassVar[PhonebookDict]
+    phonebook_crud: ClassVar[PhonebookCRUD]
+    contact_crud: ClassVar[PhonebookContactCRUD]
+    contacts: ClassVar[list[Any]]
+    num_contacts: ClassVar[int]
+    contact_count: ClassVar[int]
+    source_uuid: ClassVar[str]
+    source_name: ClassVar[str]
+    display_uuid: ClassVar[str]
+    profile_uuid: ClassVar[str]
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Moves the suite to `wazo_test_helpers.pytest_asset`, the shared plugin that
wazo-auth, wazo-chatd and others already use.
(wazo-agid and some others use the older `make_asset_fixture` with tests written for
pytest, so they need no marker and no asset class.) 

From the red bin [RB-51](https://app.notion.com/p/37baeaae6d2a810ca30ce9409779d6a0),
tracked as scaling card
[PRODUCT-332](https://app.notion.com/p/3baaeaae6d2a8109a0a9f30c0ad512af).

## The problem

`AssetLaunchingTestCase` starts the stack in `setUpClass` and stops it in
`tearDownClass`, so it destroyed and recreated the same asset back to back when
consecutive classes needed it: **153 starts for 24 assets**.

dird was the only project that still did this, because its test classes *were*
the asset classes. The plugin needs the two to be separate.

## What changes

- `DirdAssetLaunchingTestCase` and one subclass for each of the 24 assets own
  the lifecycle. `conftest.py` builds a session fixture for each of them and
  registers the plugin.
- `DirdAssetRunningTestCase` becomes a plain `unittest.TestCase`. A test class
  still names its stack with `asset = '<name>'`, and `__init_subclass__` gives
  it the matching `asset_cls` and the `usefixtures` marker.
- Seven small classmethods on the test base send `service_port`, `docker_exec`,
  `restart_service`, `stop_service`, `start_service`, `capture_logs` and
  `_run_cmd` to `asset_cls`, and `assets_root` is declared beside them. Those are
  every member of the asset class that the tests use, so the 69 calls that they
  inherited keep working and no test file changes.
- `test_database.py` and `test_dird_phonebook_backend.py` launched their stack
  from `setup_module`, which runs before the fixtures. They now use a
  module-scoped fixture that asks for the `database` asset first.
- `clean_db()` replaces `drop_all`, and the two classes that insert 5000
  contacts refresh the planner statistics afterwards. Both are needed as soon
  as a container outlives one test class, whatever starts it.
- The schema is the one of the migrations, which the db image applies.
  `setUpClass` no longer reflects each database into `Base.metadata` - that was
  there for the removed `drop_all`, and it is what made the metadata describe
  the tables of the other assets - and `test_database.py` no longer rebuilds the
  schema from the models. One DAO test relied on that: the models leave
  `dird_phonebook.tenant_uuid` nullable, the migrations declare it NOT NULL.

**Depends on [wazo-test-helpers#130](https://github.com/wazo-platform/wazo-test-helpers/pull/130)**,
which must be merged first. The plugin used to leave the compose network of
every asset allocated, and 24 assets exhaust the address pool of Docker, so the
**next** run failed. That is fixed upstream now, and this pull request carries
no copy of it. A tox environment that was built before that merge still leaks,
because the pin resolves `master.zip` when the environment is built; recreate it
with `tox -e integration --recreate`. See red bin RB-82.

Result: **24 stack starts**, and the plugin also stops an asset as soon as the
next test needs another one and reports a failed teardown at the end.

## The pattern, and how it differs

A test class in dird names its stack once:

```python
class TestFavorites(BaseDirdIntegrationTest):
    asset = 'all_routes'
```

`__init_subclass__` reads that name and gives the class two things: `asset_cls`,
the class that owns the stack, and the `usefixtures` marker that the plugin reads
to group the classes. A name that no asset knows raises at import.

An asset is a `docker-compose.<name>.override.yml` in `assets/`, and each one now
has a class beside it that names it and nothing else, as wazo-auth and wazo-chatd
do:

```python
class AllRoutesAsset(DirdAssetLaunchingTestCase):
    asset = 'all_routes'
```

`__test__ = False` sits on the base, so the 24 do not repeat it, and
`ASSET_CLASSES` reads the name back from each class rather than list the 24 names
a second time. Two classes that named the same asset would drop one of them from
that map, and its fixture with it, so `test_asset_wiring.py` counts the classes
against the map.

These 24 classes are boilerplate that differ by one string. Merging them is left
for later work.

wazo-auth and wazo-chatd name the stack in three places instead: the asset class
is written by hand, the test base sets `asset_cls`, and each test class carries
`@use_asset('<name>')`. wazo-agid and wazo-sms have one asset each and tests
written for pytest, so they need neither a marker nor an asset class.

| | wazo-dird | wazo-auth, wazo-chatd | wazo-agid, wazo-sms |
| --- | --- | --- | --- |
| assets | 24 | 6-7 | 1 |
| asset classes | 24, written by hand | written by hand | written by hand |
| marker | derived from `asset` | one for each test class | none |
| asset API in the tests | 7 wrappers to `asset_cls` | a wrapper for each method | direct, from the fixture |
| test classes | `unittest.TestCase` | `unittest.TestCase` | functions for pytest |
| plugin | `pytest_asset` | `pytest_asset` | `make_asset_fixture` |

## The decision

dird has more assets than every other project together, and 153 test classes
that already declare the asset they need. To repeat that name in a decorator and
in `asset_cls` would be 153 edits, and it would let the two disagree: the marker
decides which stack starts, `asset_cls` decides which stack the test speaks to.
The 55 marked classes of wazo-auth do agree, but nothing makes them agree. One
declaration cannot disagree with itself.

The wrappers answer a similar question. The test classes *were* the asset class,
so they reach it in 69 places across 21 files, 51 of them for `service_port`.
Seven delegations of one line each keep every one of those calls and give the
asset API a single seam; to write `asset_cls.` at each of the 69 sites would also
tie `helpers/fixtures/http.py` to that attribute, where the decorators only
receive an untyped `self`.

What it costs: the pattern is not the one of the other projects, and it depends
on how pytest collects a marker. pytest takes the markers of the whole MRO and
the plugin keeps the **first**, so only the classes that pytest collects carry
one. A marker on a base class would send every subclass to the stack of that
base class, and the tests would fail far from the cause. 8 classes were found in
that state while this was written. `suite/test_asset_wiring.py` guards both
rules, and it needs no container.

## Notes for the reviewer

- **`mark_logs` is deliberately off.** It marks the logs of `cls.service`, but
  several assets never start a dird container: the backend tests drive the
  backend inside the process of the test. The fixture raises `NoSuchService` on
  each of their tests.
- The two classes of `test_csv_backend.py` that use `asset` only to find a CSV
  file on disk keep no marker, because they need no container.
- `clean_db` uses `DELETE`, not `TRUNCATE`: `TRUNCATE` needs an ACCESS
  EXCLUSIVE lock and would queue behind the queries that dird still has in
  flight. It also deletes only the tables that the database really has, because
  `Base.metadata` belongs to the process and `setUpClass` reflects every
  database into it.

## Tests

Full suite: **570 passed, 0 failed, in 341 s (5 min 41 s)**, which leaves
**0 network** behind and keeps 84 containers to be examined. Measured with the
change of wazo-test-helpers#130 installed, which is what this branch expects.
`suite/test_asset_wiring.py` checks the wiring with no container.

## Follow-ups, out of scope here

1. The models do not describe the schema that we install: they leave
   `dird_phonebook.tenant_uuid` nullable where the migrations declare it NOT
   NULL, and they disagree on the name of the unique
   constraint of `dird_profile` (`wazo_dird/database/models.py:159` against
   `alembic/versions/baseline-2514.sql:289`, compared in
   `wazo_dird/database/queries/profile.py:69` and `:199`). The per-class
   container hid it; a duplicate profile answers 500 in place of 409 once the
   schema comes from the models. Not a production defect, since production uses
   the alembic schema.
2. The compose projects are named `dird_<asset>`, with no checkout in the name,
   so two runs of the suite on one machine share the same containers and
   database and destroy each other. A reused stack lives much longer, which
   widens the window.








<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large test-harness refactor and shared long-lived DB state change how failures propagate and how data is reset; production runtime is unaffected, but incorrect asset wiring or cleanup could cause flaky or cascading integration failures.
> 
> **Overview**
> **Reuses one Docker stack per asset** across integration test classes by adopting `wazo_test_helpers.pytest_asset`, cutting repeated compose up/down from ~153 starts to **24**.
> 
> Asset lifecycle moves to **24 `DirdAssetLaunchingTestCase` subclasses** (one per compose override); `conftest.py` registers session fixtures from `ASSET_CLASSES` and adds an autouse `mark_logs` fixture that skips assets without a `dird` container. Test classes inherit **`DirdAssetRunningTestCase`** (`unittest.TestCase`): declaring `asset = '<name>'` binds `asset_cls` and applies `usefixtures` via `__init_subclass__`, with thin delegators for `service_port`, `docker_exec`, and related asset APIs.
> 
> **Database-backed tests** no longer `reflect`/`create_all`/`drop_all` on teardown; they **`clean_db()`** with row `DELETE` (plus `VACUUM ANALYZE`) on the Alembic schema, and bulk phonebook loads call **`analyze_db()`**. `test_database` / `test_dird_phonebook_backend` replace `setup_module` with a **module-scoped pytest fixture** so the `database` asset starts before the session opens. A **`tenant` test fixture** and a stricter BaseDAO phonebook test align with migration `NOT NULL` on `tenant_uuid`.
> 
> **`test_asset_wiring.py`** asserts each collected `Test*` class’s fixture marker matches its `asset`. OpenAPI doc tests switch from the removed **`documentation`** compose override to **`phonebook_only`**. Minor hardening: `try`/`finally` on several `tearDownClass` paths and `ClassVar` typing where class attributes are set in `setUpClass`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d94ae68095f5100dac584b5401674c1a61aeaa22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->