### PR TITLE
http: fix stop-before-start shutdown race

### DIFF
--- a/wazo_dird/http_server.py
+++ b/wazo_dird/http_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 from datetime import timedelta
 
 from flask import Flask
@@ -51,6 +52,7 @@ class CoreRestApi:
         app.config.update(global_config)
         self.load_cors()
         self.server: wsgi.DynamicWSGIServer | None = None
+        self._stopped = threading.Event()
         self.app = app
         self.api = api
 
@@ -87,8 +89,13 @@ class CoreRestApi:
         for route in http_helpers.list_routes(app):
             logger.debug(route)
 
+        if self._stopped.is_set():
+            logger.warning('stop requested during startup: not starting the server')
+            return
+
         self.server.start()
 
     def stop(self) -> None:
+        self._stopped.set()
         if self.server:
             self.server.stop()

--- a/wazo_dird/tests/test_http_server.py
+++ b/wazo_dird/tests/test_http_server.py
@@ -1,0 +1,49 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+
+from wazo_dird.config import Config
+from wazo_dird.http_server import CoreRestApi
+
+
+@pytest.fixture
+def rest_api():
+    config = {
+        'auth': {},
+        'rest_api': {
+            'listen': '127.0.0.1',
+            'port': 9489,
+            'min_threads': 1,
+            'max_threads': 1,
+            'certificate': None,
+            'private_key': None,
+            'cors': {'enabled': False},
+        },
+    }
+    return CoreRestApi(cast(Config, config))
+
+
+def test_stop_before_run_does_not_raise_and_sets_the_tombstone(rest_api):
+    rest_api.stop()
+
+    assert rest_api._stopped.is_set()
+
+
+@patch('wazo_dird.http_server.wsgi')
+def test_run_after_stop_does_not_start_the_server(wsgi, rest_api):
+    rest_api.stop()
+    rest_api.run()
+
+    wsgi.DynamicWSGIServer.return_value.start.assert_not_called()
+
+
+@patch('wazo_dird.http_server.wsgi')
+def test_stop_after_run_stops_the_server(wsgi, rest_api):
+    rest_api.run()
+    rest_api.stop()
+
+    wsgi.DynamicWSGIServer.return_value.stop.assert_called_once_with()


### PR DESCRIPTION
Why: a SIGTERM landing during startup was silently lost when stop()
ran before run() assigned self.server: the stop was a no-op, run()
then started the server with nothing left to stop it, and systemd
escalated to SIGKILL after TimeoutStopSec. The window was the whole
startup phase (plugin loading, source configuration).

stop() now sets a tombstone before stopping the server, and run()
checks it after assigning self.server: whichever side loses the
race, either run() sees the tombstone or stop() sees a real server.

Same fix as wazo-auth (ITEM-589).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized lifecycle change to HTTP server startup/shutdown with tests; no auth or data-path changes.
> 
> **Overview**
> Fixes a **shutdown race** when `stop()` runs before `run()` has created `self.server` (e.g. SIGTERM during plugin/source startup): the old early `stop()` was a no-op, then `run()` still called `start()`, leaving nothing to shut down cleanly.
> 
> `CoreRestApi` now keeps a **`threading.Event` tombstone** set at the beginning of `stop()`. After building `DynamicWSGIServer` but **before** `start()`, `run()` bails out with a warning if stop was already requested; if `run()` finished setup first, `stop()` still stops the real server as before.
> 
> Adds **unit tests** for stop-before-run, run-after-stop (no `start()`), and stop-after-run (`stop()` on the server).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 922897d68d1fc24e0d67c358c35383e2d2bd1ee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->