### PR TITLE
fix(phonebook): stop duplicating the synthetic id field on contact creation

### DIFF
--- a/alembic/versions/52869e467b80_add_unique_index_contact_fields_name_.py
+++ b/alembic/versions/52869e467b80_add_unique_index_contact_fields_name_.py
@@ -1,0 +1,24 @@
+"""add_unique_index_contact_fields_name_contact_uuid
+
+Revision ID: 52869e467b80
+Revises: dc8580445700
+
+"""
+
+# alembic exposes op as a runtime proxy that mypy cannot see statically
+from alembic import op  # type: ignore[attr-defined]
+
+# revision identifiers, used by Alembic.
+revision = '52869e467b80'
+down_revision = 'dc8580445700'
+
+INDEX_NAME = 'dird_contact_fields__idx__name_contact_uuid'
+TABLE_NAME = 'dird_contact_fields'
+
+
+def upgrade() -> None:
+    op.create_index(INDEX_NAME, TABLE_NAME, ['name', 'contact_uuid'], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index(INDEX_NAME, table_name=TABLE_NAME)

--- a/alembic/versions/dc8580445700_dedupe_contact_fields_rows.py
+++ b/alembic/versions/dc8580445700_dedupe_contact_fields_rows.py
@@ -1,0 +1,43 @@
+"""dedupe_contact_fields_rows
+
+Revision ID: dc8580445700
+Revises: 4f2c91ab07de
+
+"""
+
+import sqlalchemy as sa
+
+# alembic exposes op as a runtime proxy that mypy cannot see statically
+from alembic import op  # type: ignore[attr-defined]
+
+# revision identifiers, used by Alembic.
+revision = 'dc8580445700'
+down_revision = '4f2c91ab07de'
+
+_contact_fields = sa.table(
+    'dird_contact_fields',
+    sa.column('id', sa.Integer),
+    sa.column('name', sa.Text),
+    sa.column('contact_uuid', sa.String),
+)
+
+
+def upgrade() -> None:
+    other = _contact_fields.alias('other')
+    keep_id = (
+        sa.select(sa.func.min(other.c.id))
+        .where(
+            other.c.contact_uuid == _contact_fields.c.contact_uuid,
+            other.c.name == _contact_fields.c.name,
+        )
+        .scalar_subquery()
+    )
+    op.get_bind().execute(
+        _contact_fields.delete().where(
+            _contact_fields.c.id > keep_id,
+        )
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/wazo_dird/database/models.py
+++ b/wazo_dird/database/models.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -69,6 +69,12 @@ class ContactFields(Base):
     __tablename__ = 'dird_contact_fields'
     __table_args__ = (
         schema.Index('dird_contact_fields__idx__contact_uuid', 'contact_uuid'),
+        schema.Index(
+            'dird_contact_fields__idx__name_contact_uuid',
+            'name',
+            'contact_uuid',
+            unique=True,
+        ),
     )
 
     id = Column(Integer(), primary_key=True)

--- a/wazo_dird/database/models.py
+++ b/wazo_dird/database/models.py
@@ -19,6 +19,7 @@ from sqlalchemy.dialects.postgresql import ARRAY, HSTORE, JSON, UUID
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import declarative_base, relationship
+from sqlalchemy.orm.collections import attribute_mapped_collection
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +56,7 @@ class Contact(Base):
 
     fields = relationship(
         lambda: ContactFields,
+        collection_class=attribute_mapped_collection('name'),
         lazy='subquery',
         passive_deletes=True,
         cascade='all, delete-orphan',
@@ -62,7 +64,7 @@ class Contact(Base):
 
     @property
     def fields_dict(self) -> dict[str, Any]:
-        return {field.name: field.value for field in self.fields}
+        return {name: field.value for name, field in self.fields.items()}
 
 
 class ContactFields(Base):

--- a/wazo_dird/database/queries/phonebook.py
+++ b/wazo_dird/database/queries/phonebook.py
@@ -429,10 +429,7 @@ class PhonebookContactCRUD(BaseDAO):
         contact.fields = [
             ContactFields(name=name, value=value, contact_uuid=contact.uuid)
             for name, value in contact_body.items()
-        ] + [
-            ContactFields(name='id', value=contact.uuid, contact_uuid=contact.uuid)
-            for name, value in contact_body.items()
-        ]
+        ] + [ContactFields(name='id', value=contact.uuid, contact_uuid=contact.uuid)]
 
     def _get_contact(
         self,

--- a/wazo_dird/database/queries/phonebook.py
+++ b/wazo_dird/database/queries/phonebook.py
@@ -426,10 +426,21 @@ class PhonebookContactCRUD(BaseDAO):
         self, s: BaseSession, contact: Contact, contact_body: dict[str, Any]
     ) -> None:
         assert contact.uuid
-        contact.fields = [
-            ContactFields(name=name, value=value, contact_uuid=contact.uuid)
-            for name, value in contact_body.items()
-        ] + [ContactFields(name='id', value=contact.uuid, contact_uuid=contact.uuid)]
+        new_fields = {
+            name: value for name, value in contact_body.items() if name != 'id'
+        }
+        new_fields['id'] = contact.uuid
+
+        for name in contact.fields.keys() - new_fields.keys():
+            del contact.fields[name]
+
+        for name, value in new_fields.items():
+            if name in contact.fields:
+                contact.fields[name].value = value
+            else:
+                contact.fields[name] = ContactFields(
+                    name=name, value=value, contact_uuid=contact.uuid
+                )
 
     def _get_contact(
         self,


### PR DESCRIPTION



<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Ships a data-deleting Alembic migration and changes how phonebook contact fields are written; scope is narrow but upgrades must succeed before the unique index applies.
> 
> **Overview**
> Fixes contact field persistence so each contact gets **one** synthetic `id` row (contact UUID) instead of duplicating it, and updates create/edit to **merge** fields in place rather than replacing the whole collection.
> 
> `Contact.fields` is now a name-keyed collection (`attribute_mapped_collection`), and `_set_contact_fields` adds/updates/removes rows to match the request body while always setting `id` from the contact UUID (ignoring any client `id`).
> 
> **Database:** a migration **dedupes** existing `(name, contact_uuid)` duplicates (keeps lowest `id`), then adds a **unique index** on those columns so duplicates cannot return.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4c73551d06eddd65399b2b16984f37c6919f8d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->