### PR TITLE
ITEM-606 BUG 450 fix model schema drift

### DIFF
--- a/integration_tests/suite/helpers/fixtures/db.py
+++ b/integration_tests/suite/helpers/fixtures/db.py
@@ -1,11 +1,33 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from functools import wraps
 
 from wazo_dird import exception
+from wazo_dird.database import models
 
 from ..utils import new_uuid, random_string
+
+
+def tenant(**tenant_args):
+    tenant_args.setdefault('tenant_uuid', new_uuid())
+
+    def decorator(decorated):
+        @wraps(decorated)
+        def wrapper(self, *args, **kwargs):
+            tenant = self.tenant_crud.create(**tenant_args)
+            try:
+                return decorated(self, tenant, *args, **kwargs)
+            finally:
+                # `TenantCRUD` has no delete.
+                with self.tenant_crud.new_session() as session:
+                    session.query(models.Tenant).filter(
+                        models.Tenant.uuid == tenant['uuid']
+                    ).delete()
+
+        return wrapper
+
+    return decorator
 
 
 def display(**display_args):

--- a/integration_tests/suite/test_database.py
+++ b/integration_tests/suite/test_database.py
@@ -1725,6 +1725,24 @@ class TestProfileCRUD(_BaseTest):
         )
 
     @fixtures.display(tenant_uuid=TENANT_UUID)
+    def test_create_duplicate(self, display):
+        body = {
+            'tenant_uuid': TENANT_UUID,
+            'name': 'my-duplicate-profile',
+            'display': {'uuid': display['uuid']},
+            'services': {},
+        }
+        result = self.profile_crud.create(body)
+
+        try:
+            assert_that(
+                calling(self.profile_crud.create).with_args(body),
+                raises(exception.DuplicatedProfileException),
+            )
+        finally:
+            self.profile_crud.delete(None, result['uuid'])
+
+    @fixtures.display(tenant_uuid=TENANT_UUID)
     def test_create_unknown_source(self, display):
         body: dict[str, Any] = {
             'tenant_uuid': TENANT_UUID,

--- a/integration_tests/suite/test_database.py
+++ b/integration_tests/suite/test_database.py
@@ -101,6 +101,7 @@ class _BaseTest(unittest.TestCase):
         self.display_crud = database.DisplayCRUD(Session)
         self.profile_crud = database.ProfileCRUD(Session)
         self.source_crud = database.SourceCRUD(Session)
+        self.tenant_crud = database.TenantCRUD(Session)
 
         self._contact_1 = {
             'firtname': 'Finley',
@@ -175,7 +176,8 @@ class _BasePhonebookCRUDTest(_BaseTest):
 
 
 class TestBaseDAO(_BaseTest):
-    def test_that_an_unexpected_error_does_not_block_the_current_Session(self):
+    @fixtures.tenant()
+    def test_that_an_unexpected_error_does_not_block_the_current_Session(self, tenant):
         dao = base.BaseDAO(Session)
 
         try:
@@ -190,8 +192,7 @@ class TestBaseDAO(_BaseTest):
 
         try:
             with dao.new_session() as s:
-                phonebook = database.Phonebook(name='bar')
-                s.add(phonebook)
+                s.add(database.Phonebook(name='bar', tenant_uuid=tenant['uuid']))
         except exc.InvalidRequestError:
             self.fail('Should not raise')
 

--- a/wazo_dird/database/models.py
+++ b/wazo_dird/database/models.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -149,14 +149,18 @@ class Phonebook(Base):
     )
     name = Column(String(255), nullable=False)
     description = Column(Text)
-    tenant_uuid = Column(String(UUID_LENGTH), ForeignKey('dird_tenant.uuid'))
+    tenant_uuid = Column(
+        String(UUID_LENGTH),
+        ForeignKey('dird_tenant.uuid', ondelete='CASCADE'),
+        nullable=False,
+    )
 
 
 class Profile(Base):
     __tablename__ = 'dird_profile'
     __table_args__ = (
         schema.UniqueConstraint('uuid', 'tenant_uuid'),
-        schema.UniqueConstraint('name', 'tenant_uuid'),
+        schema.UniqueConstraint('name', 'tenant_uuid', name='dird_profile_tenant_name'),
         schema.ForeignKeyConstraint(
             ('display_uuid', 'display_tenant_uuid'),
             ('dird_display.uuid', 'dird_display.tenant_uuid'),


### PR DESCRIPTION
- **fix(database): align models with the schema that alembic installs**
- **test(integration): give the phonebook of a DAO test its tenant**
- **test(integration): cover the profile duplicate-name constraint**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Model-only alignment with existing migration constraints plus test fixes; no new runtime API behavior beyond reflecting schema that should already be in production DBs.
> 
> **Overview**
> **Aligns ORM definitions with the database Alembic installs** so metadata and migrations stay in sync (BUG 450).
> 
> `Phonebook.tenant_uuid` is now **required** and uses **`ondelete='CASCADE'`** on the tenant FK. The profile **per-tenant name uniqueness** constraint is given the explicit name **`dird_profile_tenant_name`**, matching the installed schema.
> 
> Integration tests add a **`@fixtures.tenant()`** helper (create tenant, delete via session when `TenantCRUD` has no delete). The BaseDAO session test provisions a real tenant and sets **`tenant_uuid`** on the second phonebook insert. **`ProfileCRUD`** gains **`test_create_duplicate`**, asserting a second profile with the same name/tenant raises **`DuplicatedProfileException`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cce04937e3c6ecfd72c2364b0a2411dd101e2a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->