### PR TITLE
BUG-455: add the missing dird_profile/dird_profile_service_source constraints

### DIFF
--- a/alembic/versions/30ae0fd93125_add_missing_dird_profile_service_source_.py
+++ b/alembic/versions/30ae0fd93125_add_missing_dird_profile_service_source_.py
@@ -1,0 +1,85 @@
+"""add missing dird_profile_service_source constraints
+
+Revision ID: 30ae0fd93125
+Revises: f9dbff02cc91
+
+"""
+
+import sqlalchemy as sa
+
+# alembic exposes op as a runtime proxy that mypy cannot see statically
+from alembic import op  # type: ignore[attr-defined]
+
+# revision identifiers, used by Alembic.
+revision = '30ae0fd93125'
+down_revision = 'f9dbff02cc91'
+
+_profile_service_source = sa.table(
+    'dird_profile_service_source',
+    sa.column('profile_service_uuid', sa.String),
+    sa.column('source_uuid', sa.String),
+    sa.column('profile_tenant_uuid', sa.String),
+    sa.column('source_tenant_uuid', sa.String),
+)
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+
+    duplicates = connection.execute(
+        sa.select(sa.func.count()).select_from(
+            sa.select(sa.literal(1))
+            .select_from(_profile_service_source)
+            .group_by(
+                _profile_service_source.c.profile_service_uuid,
+                _profile_service_source.c.source_uuid,
+            )
+            .having(sa.func.count() > 1)
+            .subquery()
+        )
+    ).scalar()
+    if duplicates:
+        raise RuntimeError(
+            f'{duplicates} duplicate (profile_service_uuid, source_uuid) '
+            'pair(s) in dird_profile_service_source; BUG-455 assumed this '
+            'never happens. Investigate before adding this primary key.'
+        )
+
+    tenant_violations = connection.execute(
+        sa.select(sa.func.count())
+        .select_from(_profile_service_source)
+        .where(
+            _profile_service_source.c.profile_tenant_uuid
+            != _profile_service_source.c.source_tenant_uuid
+        )
+    ).scalar()
+    if tenant_violations:
+        raise RuntimeError(
+            f'{tenant_violations} row(s) in dird_profile_service_source have '
+            'profile_tenant_uuid != source_tenant_uuid; BUG-455 assumed this '
+            'never happens. Investigate before adding this constraint.'
+        )
+
+    # Unnamed: Postgres auto-names these dird_profile_service_source_pkey
+    # and dird_profile_service_source_check, matching the unnamed
+    # primary_key=True columns and CheckConstraint already in
+    # wazo_dird/database/models.py.
+    op.execute(
+        'ALTER TABLE dird_profile_service_source '
+        'ADD PRIMARY KEY (profile_service_uuid, source_uuid)'
+    )
+    op.execute(
+        'ALTER TABLE dird_profile_service_source '
+        'ADD CHECK (profile_tenant_uuid = source_tenant_uuid)'
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        'ALTER TABLE dird_profile_service_source '
+        'DROP CONSTRAINT dird_profile_service_source_check'
+    )
+    op.execute(
+        'ALTER TABLE dird_profile_service_source '
+        'DROP CONSTRAINT dird_profile_service_source_pkey'
+    )

--- a/alembic/versions/f9dbff02cc91_add_missing_dird_profile_tenant_check_.py
+++ b/alembic/versions/f9dbff02cc91_add_missing_dird_profile_tenant_check_.py
@@ -1,0 +1,44 @@
+"""add missing dird_profile tenant check constraint
+
+Revision ID: f9dbff02cc91
+Revises: 52869e467b80
+
+"""
+
+import sqlalchemy as sa
+
+# alembic exposes op as a runtime proxy that mypy cannot see statically
+from alembic import op  # type: ignore[attr-defined]
+
+# revision identifiers, used by Alembic.
+revision = 'f9dbff02cc91'
+down_revision = '52869e467b80'
+
+_profile = sa.table(
+    'dird_profile',
+    sa.column('tenant_uuid', sa.String),
+    sa.column('display_tenant_uuid', sa.String),
+)
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    violations = connection.execute(
+        sa.select(sa.func.count())
+        .select_from(_profile)
+        .where(_profile.c.tenant_uuid != _profile.c.display_tenant_uuid)
+    ).scalar()
+    if violations:
+        raise RuntimeError(
+            f'{violations} row(s) in dird_profile have tenant_uuid != '
+            'display_tenant_uuid; BUG-455 assumed this never happens. '
+            'Investigate before adding this constraint.'
+        )
+
+    # Unnamed: Postgres auto-names it dird_profile_check, matching the
+    # unnamed CheckConstraint already in wazo_dird/database/models.py.
+    op.execute('ALTER TABLE dird_profile ADD CHECK (tenant_uuid = display_tenant_uuid)')
+
+
+def downgrade() -> None:
+    op.execute('ALTER TABLE dird_profile DROP CONSTRAINT dird_profile_check')


### PR DESCRIPTION
## Summary
- Adds two alembic migrations installing the constraints `wazo_dird/database/models.py` already declares but the migrations never actually created: `dird_profile`'s check constraint (`tenant_uuid = display_tenant_uuid`), and `dird_profile_service_source`'s composite primary key (`profile_service_uuid, source_uuid`) plus its check constraint (`profile_tenant_uuid = source_tenant_uuid`).
- Both migrations verify no existing row would violate the new constraint before adding it, raising a clear error instead of applying silently if any are found.

## Context
Found by PRODUCT-336's `check_db_schema.py` CI job (diffs the model-derived schema against the real migrated one). Traced every production code path that creates or edits a `Profile`/`ProfileServiceSource` row: `display_tenant_uuid`/`source_tenant_uuid` are always forced equal to `tenant_uuid`/`profile_tenant_uuid` respectively, unconditionally, on both create and edit — so neither check constraint can be violated by any code path today. `profile_service_uuid` is a fresh UUID on every insert, so the missing primary key can't have been violated either. Full analysis in BUG-455.

Related, on a separate branch (`PRODUCT-336-check-db-schema-drift`, not yet merged): `f5b7c96c` and `0e41ddf1` are the schema-drift tooling and the earlier BUG-450 model fixes that led to finding this gap.

Closes BUG-455.

## Test plan
- [x] `pre-commit run` clean on both migration files.
- [x] Verified with `check_db_schema.py` against a throwaway Postgres: both new constraints now match between the model-derived and migration-derived schema (no longer appear in the diff), and `alembic upgrade head` completes without the migrations' data-safety checks raising (confirming zero existing violations in a fresh baseline install — real production data still worth a final check before deploying).
- [ ] CI

Depends-On: https://github.com/wazo-platform/wazo-dird/pull/278
Depends-On: https://github.com/TinxHQ/wazo-production-sf-jobs/pull/54
Depends-On: https://github.com/wazo-platform/wazo-tools/pull/82