### PR TITLE
ITEM-606-review-fixes

### DIFF
--- a/alembic/versions/30ae0fd93125_add_missing_dird_profile_service_source_.py
+++ b/alembic/versions/30ae0fd93125_add_missing_dird_profile_service_source_.py
@@ -27,6 +27,18 @@ _profile_service_source = sa.table(
 def upgrade() -> None:
     connection = op.get_bind()
 
+    # The composite FKs use MATCH SIMPLE, so a NULL in either key column
+    # escapes FK enforcement; such orphans would make the primary key
+    # creation below abort.
+    connection.execute(
+        _profile_service_source.delete().where(
+            sa.or_(
+                _profile_service_source.c.profile_service_uuid.is_(None),
+                _profile_service_source.c.source_uuid.is_(None),
+            )
+        )
+    )
+
     # profile_tenant_uuid/source_tenant_uuid are each pinned by an FK to a
     # single parent row, so duplicates here are exact duplicates; keep one
     # per pair via ctid.

--- a/wazo_dird/database/models.py
+++ b/wazo_dird/database/models.py
@@ -169,7 +169,6 @@ class Phonebook(Base):
         _dird_phonebook_id_seq,
         server_default=_dird_phonebook_id_seq.next_value(),
         nullable=False,
-        unique=True,
     )
     uuid = Column(
         UUID(as_uuid=False), server_default=text('uuid_generate_v4()'), primary_key=True


### PR DESCRIPTION
- **migration: delete NULL-key rows before adding the primary key**
- **fix(database): drop the redundant unique flag on dird_phonebook.id**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The migration permanently deletes orphan association rows with NULL keys during upgrade; behavior is intentional but affects live data if such rows exist.
> 
> **Overview**
> Fixes two schema/migration issues flagged in review.
> 
> The **`dird_profile_service_source`** Alembic upgrade now **deletes rows with NULL `profile_service_uuid` or `source_uuid`** before deduplication and primary-key creation. Those rows are not enforced by the composite foreign keys (MATCH SIMPLE), and would cause the migration to fail when adding the composite primary key.
> 
> On **`Phonebook`**, the column-level **`unique=True` on `id` is removed**; **`id` uniqueness is unchanged** because it remains defined by the existing `dird_phonebook_id` unique constraint in `__table_args__`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bd54f3cf3c4b251ac64a9b5cebc868d53677c77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->