### PR TITLE
BUG-465: reject limit=0 on phonebook contact listing

### DIFF
--- a/integration_tests/suite/test_personal.py
+++ b/integration_tests/suite/test_personal.py
@@ -45,6 +45,11 @@ class TestListPersonal(PersonalOnlyTestCase):
 
         assert_that(result['items'], contains_exactly())
 
+    def test_that_a_zero_limit_returns_400(self):
+        result = self.list_personal_result(VALID_TOKEN_MAIN_TENANT, limit=0)
+
+        assert_that(result.status_code, equal_to(400))
+
 
 class TestDeletedUser(BaseDirdIntegrationTest):
     asset = 'personal_only'

--- a/integration_tests/suite/test_personal.py
+++ b/integration_tests/suite/test_personal.py
@@ -45,10 +45,18 @@ class TestListPersonal(PersonalOnlyTestCase):
 
         assert_that(result['items'], contains_exactly())
 
-    def test_that_a_zero_limit_returns_400(self):
-        result = self.list_personal_result(VALID_TOKEN_MAIN_TENANT, limit=0)
+    def test_that_an_invalid_limit_or_offset_returns_400(self):
+        for value in [0, -1]:
+            result = self.list_personal_result(VALID_TOKEN_MAIN_TENANT, limit=value)
+            assert_that(result.status_code, equal_to(400), f'limit={value}')
 
+        result = self.list_personal_result(VALID_TOKEN_MAIN_TENANT, offset=-1)
         assert_that(result.status_code, equal_to(400))
+
+    def test_that_a_valid_limit_and_offset_are_accepted(self):
+        result = self.list_personal_result(VALID_TOKEN_MAIN_TENANT, limit=1, offset=0)
+
+        assert_that(result.status_code, equal_to(200))
 
 
 class TestDeletedUser(BaseDirdIntegrationTest):

--- a/integration_tests/suite/test_phonebook.py
+++ b/integration_tests/suite/test_phonebook.py
@@ -452,6 +452,15 @@ class TestContactGet(_BasePhonebookContactTestCase):
 
 
 class TestContactList(_BasePhonebookContactTestCase):
+    def test_that_a_zero_limit_returns_400(self):
+        self.set_tenants(self.tenant_1.name)
+
+        result = self.list_phonebook_contacts(
+            self.phonebook_1['uuid'], tenant=self.tenant_1.uuid, limit=0
+        )
+
+        assert_that(result.status_code, equal_to(400))
+
     def test_unknown_tenant_or_phonebook(self):
         self.set_tenants(self.tenant_2.name)
         result = self.list_phonebook_contacts(

--- a/wazo_dird/plugins/personal/http.py
+++ b/wazo_dird/plugins/personal/http.py
@@ -13,10 +13,13 @@ from typing import TYPE_CHECKING, Any
 
 from flask import Response, request
 from flask_restful import reqparse
+from marshmallow import ValidationError
 from xivo.tenant_flask_helpers import Tenant
 
 from wazo_dird.auth import get_user_uuid, required_acl
 from wazo_dird.http import LegacyAuthResource, get_json_body
+
+from .schemas import list_schema
 
 if TYPE_CHECKING:
     from wazo_dird.database.queries.base import ContactInfo
@@ -65,10 +68,11 @@ class PersonalAll(LegacyAuthResource):
     ) -> tuple[dict[str, Any], int] | tuple[str, int] | Response:
         user_uuid = get_user_uuid()
         try:
+            search_params = dict(request.args) | list_schema.load(request.args)
             contacts = self.personal_service.list_contacts_raw(
-                user_uuid, search_params=request.args
+                user_uuid, search_params=search_params
             )
-        except ValueError as e:
+        except (ValidationError, ValueError) as e:
             error = {'reason': str(e), 'timestamp': [time()], 'status_code': 400}
             return error, 400
 

--- a/wazo_dird/plugins/personal/schemas.py
+++ b/wazo_dird/plugins/personal/schemas.py
@@ -1,0 +1,21 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from marshmallow import EXCLUDE, Schema
+from xivo.mallow import fields, validate
+
+
+class ListSchema(Schema):
+    # order is validated against the contacts themselves, in the DAO: personal
+    # contact fields are free-form, so there is no column list to validate
+    # against here.
+    class Meta:
+        unknown = EXCLUDE
+
+    limit = fields.Integer(validate=validate.Range(min=1), load_default=None)
+    offset = fields.Integer(validate=validate.Range(min=0), load_default=0)
+
+
+list_schema = ListSchema()

--- a/wazo_dird/plugins/phonebook/schemas.py
+++ b/wazo_dird/plugins/phonebook/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, TypedDict, cast
 
-from marshmallow import fields
+from xivo.mallow import fields, validate
 from xivo.mallow_helpers import ListSchema
 
 from wazo_dird.utils import projection
@@ -20,6 +20,7 @@ class ContactListSchema(ListSchema):
     sort_insensitive_columns = ['firstname', 'lastname', 'name']
 
     recurse = fields.Boolean(load_default=False)
+    limit = fields.Integer(validate=validate.Range(min=1), load_default=None)
 
     def load_count(self, args: Mapping[str, Any], **kwargs: Any) -> CountParams:
         return cast(CountParams, projection(self.load(args, **kwargs), ['search']))

--- a/wazo_dird/plugins/phonebook_backend/schemas.py
+++ b/wazo_dird/plugins/phonebook_backend/schemas.py
@@ -47,5 +47,7 @@ class ContactListSchema(_ListSchema):
     default_sort_column = None
     sort_insensitive_columns = ['firstname', 'lastname']
 
+    limit = fields.Integer(validate=validate.Range(min=1), load_default=None)
+
 
 contact_list_schema = ContactListSchema()


### PR DESCRIPTION
## Why

`limit=0` meant two different things depending on which contact list you asked for:

- `GET /0.1/phonebooks/{uuid}/contacts?limit=0` → **200 with every contact**. The phonebook path only applied the limit when truthy, so `limit=0` applied none — returning the large response ITEM-582 set out to avoid.
- `GET /0.1/personal?limit=0` → **400** `"limit must be a positive number"`, from `BaseDAO.validate_parameters`.

Reported as **BUG-465**.

## What changed

`limit=0` is now rejected on both, and both express the rule in a marshmallow schema rather than one doing it at the HTTP layer and the other in the DAO.

**Phonebook** — `limit` overridden with `Range(min=1)` on both contact-listing schemas:
- `phonebook/schemas.py::ContactListSchema` — `GET /phonebooks/{uuid}/contacts`
- `phonebook_backend/schemas.py::ContactListSchema` — `GET /backends/phonebook/sources/{uuid}/contacts` (same DAO, different route)

The override uses `xivo.mallow`'s `fields.Integer`/`validate.Range` rather than plain marshmallow, matching the upstream `ListSchema` definition so the 400 body keeps wazo's structured `constraint_id`/`constraint` error format.

**Personal** — new `personal/schemas.py` validating `limit` (`Range(min=1)`) and `offset` (`Range(min=0)`), applied in `PersonalAll.get`. Two constraints shaped this:
- The personal resource is a `LegacyAuthResource`, whose base has no `handle_validation_exception`, so a `ValidationError` would otherwise surface as a 500. It is caught locally and returned in personal's existing `{reason, timestamp, status_code}` shape — response format is unchanged.
- `order` deliberately stays in the DAO. Personal contact fields are free-form (arbitrary imported columns), so there is no column list to validate against in a schema; validation there is necessarily data-dependent.

Not changed: the **deprecated** phonebook API validates through its own `_ArgParser` instead of a marshmallow schema, and still drops a falsy limit. Left alone — different validation path, and deprecated.

## Behaviour change

`limit=0` on the phonebook contact-listing endpoints goes from `200` + all contacts to `400`. Callers sending `limit=0` and relying on getting everything back must omit `limit` instead. Personal's outcome is unchanged (already 400).

## Note on the DAO layer

Now that #273 is merged, `PhonebookContactCRUD._paginate_contact_uuids` still treats a falsy limit as "no limit" (`if limit:`), and `test_that_a_zero_limit_means_no_limit` asserts that at the DAO level. Both remain valid — the DAO can no longer receive `limit=0` through the API, so the two layers do not conflict — but the DAO permissiveness is now unreachable from HTTP and carries a `TODO` marking it for follow-up.

## Validation

- Red/green verified: with the phonebook fix reverted its test fails (`Expected: <400>`, got 200) while personal already passes — isolating exactly the reported inconsistency.
- Linters, black, **mypy**, isort — green.
- Integration: **142 passed** across `test_phonebook.py`, `test_personal.py`, `test_phonebook_http.py`, `test_dird_phonebook_backend.py`, `test_phonebook_deprecated.py` — re-run after rebasing onto the post-#273-merge base. The existing test pinning personal's `order` error body still passes, confirming the response format is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
